### PR TITLE
Notation implementation

### DIFF
--- a/src/circuit/circuit_parameters.rs
+++ b/src/circuit/circuit_parameters.rs
@@ -9,50 +9,47 @@ use ark_ff::PrimeField;
 use ark_ff::*;
 use plonk::commitment::{HomomorphicCommitment, IPA, KZG10};
 
+
+
+pub struct Curve<E>;
+
+pub trait CurveParameters {
+    type ScalarField: PrimeField + HashToField;
+    type BaseField: PrimeField + HashToField;
+    type TE: TEModelParameters<
+        ScalarField = Self::ScalarField,
+        BaseField = Self::BaseField,
+    >;
+
+    type PC: HomomorphicCommitment<Self::ScalarField>;
+
+    fn com_r(x: &[u8], rand: BigInteger256) -> Self::ScalarField {
+        com(x, rand)
+    }
+    
+    fn com_q(x: &[u8], rand: BigInteger256) -> Self::BaseField {
+        com(x, rand)
+    }
+}
+
+
+
 pub trait CircuitParameters {
+
     //               Inner Curve     Curve    Outer Curve
     // Scalar Field                    Fr         Fq
     //   Base Field      Fr            Fq
 
-    // Curve
-    type CurveScalarField: PrimeField + HashToField;
-    type CurveBaseField: PrimeField + HashToField;
-    type Curve: TEModelParameters<
-        ScalarField = Self::CurveScalarField,
-        BaseField = Self::CurveBaseField,
-    >;
-    // Inner curve
-    type InnerCurveScalarField: PrimeField + HashToField;
-    type InnerCurve: TEModelParameters<
-        ScalarField = Self::InnerCurveScalarField,
-        BaseField = Self::CurveScalarField,
-    >;
-    // Outer curve
-    type OuterCurveBaseField: PrimeField + HashToField;
-    type OuterCurve: SWModelParameters<
-        ScalarField = Self::CurveBaseField,
-        BaseField = Self::OuterCurveBaseField,
-    >;
-
-    type CurvePC: HomomorphicCommitment<Self::CurveScalarField>;
-    type OuterCurvePC: HomomorphicCommitment<Self::CurveBaseField>;
-
-    // F_q is the scalar field of *Curve*
-    fn com_r(x: &[u8], rand: BigInteger256) -> Self::CurveScalarField {
-        com(x, rand)
-    }
-
-    // F_p is the base field of *Curve*
-    fn com_q(x: &[u8], rand: BigInteger256) -> Self::CurveBaseField {
-        com(x, rand)
-    }
+    type MainCurve : CurveParameters;
+    type InnerCurve : CurveParameters;
+    type OuterCurve : CurveParameters;
 }
 
 // // We decided to continue with KZG for now.
 // pub struct DLCircuitParameters {}
 
 // impl CircuitParameters for DLCircuitParameters {
-//     type CurveScalarField = ark_vesta::Fr;
+    // type CurveScalarField = ark_vesta::Fr;
 //     type CurveBaseField = ark_vesta::Fq;
 //     type Curve = ark_vesta::VestaParameters;
 //     type InnerCurveScalarField = ark_pallas::Fr;
@@ -65,14 +62,29 @@ pub trait CircuitParameters {
 
 pub struct PairingCircuitParameters {}
 
+pub struct PairingMain;
+pub struct PairingInner;
+pub struct PairingOuter;
+
+impl CurveParameters for Curve<PairingMain> {
+    type ScalarField = ark_bls12_377::Fr;
+    type BaseField = ark_bls12_377::Fq;
+    type TE = ark_bls12_377::g1::Parameters; 
+    type PC = KZG10<ark_bls12_377::Bls12_377>;
+}
+
+impl CurveParameters for Curve<PairingInner> {
+    type ScalarField = ark_ed_on_bls12_377::Fr;
+    type TE = ark_ed_on_bls12_377::EdwardsParameters;
+}
+impl CurveParameters for Curve<PairingOuter> {
+    type BaseField = ark_bw6_761::Fq;
+    type TE = ark_bw6_761::g1::Parameters;
+    type PC = KZG10<ark_bw6_761::BW6_761>;
+}
+
 impl CircuitParameters for PairingCircuitParameters {
-    type CurveScalarField = ark_bls12_377::Fr;
-    type CurveBaseField = ark_bls12_377::Fq;
-    type Curve = ark_bls12_377::g1::Parameters;
-    type InnerCurveScalarField = ark_ed_on_bls12_377::Fr;
-    type InnerCurve = ark_ed_on_bls12_377::EdwardsParameters;
-    type OuterCurveBaseField = ark_bw6_761::Fq;
-    type OuterCurve = ark_bw6_761::g1::Parameters;
-    type CurvePC = KZG10<ark_bls12_377::Bls12_377>;
-    type OuterCurvePC = KZG10<ark_bw6_761::BW6_761>;
+    type MainCurve = Curve<PairingMain>;
+    type InnerCurve = Curve<PairingInner>;
+    type OuterCurve = Curve<PairingOuter>;
 }


### PR DESCRIPTION
Code proposal for the notation discussed in https://github.com/heliaxdev/taiga/pull/24

It's too verbose for my taste on the user front. Here's an example of how to use it from the action.rs file

```
    fn check_spent_note_addr_integrity(
        send_vp_hash: <CP::MainCurve as CurveParameters>::BaseField,
        recv_vp_hash: <CP::MainCurve as CurveParameters>::BaseField,
        note_rcm: BigInteger256,
        nk: BigInteger256,
        note_owner_addr: <CP::MainCurve as CurveParameters>::ScalarField,
    ) {
        assert_eq!(
            CP::MainCurve::com_r(
                &[
                    CP::MainCurve::com_r(
                        &[
                            send_vp_hash.into_repr().to_bytes_le().as_slice(),
                            nk.to_bytes_le().as_slice()
                        ]
                        .concat(),
                        BigInteger256::from(0)
                    )
                    .into_repr()
                    .to_bytes_le(),
                    recv_vp_hash.into_repr().to_bytes_le()
                ]
                .concat(),
                note_rcm,
            ),
            note_owner_addr
        );
    }
```

Here's how it looks right now:
```
impl<CP: CircuitParameters> Action<CP> {
    fn check_spent_note_addr_integrity(
        send_vp_hash: CP::CurveBaseField,
        recv_vp_hash: CP::CurveBaseField,
        note_rcm: BigInteger256,
        nk: BigInteger256,
        note_owner_addr: CP::CurveScalarField,
    ) {
        assert_eq!(
            CP::com_r(
                &[
                    CP::com_r(
                        &[
                            send_vp_hash.into_repr().to_bytes_le().as_slice(),
                            nk.to_bytes_le().as_slice()
                        ]
                        .concat(),
                        BigInteger256::from(0)
                    )
                    .into_repr()
                    .to_bytes_le(),
                    recv_vp_hash.into_repr().to_bytes_le()
                ]
                .concat(),
                note_rcm,
            ),
            note_owner_addr
        );
    }
```


Can anyone think of a way to avoid the `<CP::MainCurve as CurveParameters>::X` pattern?
