### PR TITLE
update ci check strategy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI checks
 
-on: [push, pull_request]
+# on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   test:


### PR DESCRIPTION
From Gianmarco, our GitHub action resource is limited.
So remove some checks we may not need so far, only use `ubuntu-latest`, trigger ci when pulling request.
