### PR TITLE
New layer of curves for efficient hash circuit (#66)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,15 +7,13 @@ edition = "2021"
 
 [dependencies]
 ark-serialize = { version = "^0.3.0", default-features = false }
-ark-ff = { version = "^0.3.0", default-features = false }
-ark-ec = { version = "^0.3.0", default-features = false }
+ark-ff = { git="https://github.com/simonmasson/algebra", rev="e2ea75c" }
+ark-ec = { git="https://github.com/simonmasson/algebra", rev="e2ea75c" }
 ark-poly-commit = "0.3"
 ark-poly = "0.3"
-ark-bls12-377 = "0.3"
-ark-ed-on-bls12-377 = "0.3"
-ark-bw6-761 = "0.3"
-ark-pallas = "0.3"
-ark-vesta = "0.3"
+ark-bls12-381-new = { git="https://github.com/simonmasson/curves/", branch="new-pairing-layer" }
+ark-ed-on-bls12-381-new = { git="https://github.com/simonmasson/curves/", branch="new-pairing-layer" }
+ark-bw6-764-new = { git="https://github.com/simonmasson/curves/", branch="new-pairing-layer" }
 
 merlin = { version = "3.0", default-features = false }
 rand = "0.8.4"
@@ -33,8 +31,6 @@ blake2b_simd = "1"
 ark-std = "0.3"
 
 [patch.crates-io]
-ark-bls12-377 = { git="https://github.com/simonmasson/curves/", branch="new-curve-models" }
-ark-ed-on-bls12-377 = { git="https://github.com/simonmasson/curves/", branch="new-curve-models" }
-ark-bw6-761 = { git="https://github.com/simonmasson/curves/", branch="new-curve-models" }
-ark-pallas = { git="https://github.com/simonmasson/curves/", branch="new-curve-models" }
-ark-vesta = { git="https://github.com/simonmasson/curves/", branch="new-curve-models" }
+ark-serialize = { git="https://github.com/simonmasson/algebra", rev="e2ea75c" }
+ark-ff = { git="https://github.com/simonmasson/algebra", rev="e2ea75c" }
+ark-ec = { git="https://github.com/simonmasson/algebra", rev="e2ea75c" }

--- a/src/circuit/action_circuit.rs
+++ b/src/circuit/action_circuit.rs
@@ -76,7 +76,7 @@ fn action_circuit_test() {
     type PC = <CP as CircuitParameters>::CurvePC;
     use crate::action::*;
     use crate::merkle_tree::MerklePath;
-    use crate::poseidon::POSEIDON_HASH_PARAM_BLS12_377_SCALAR_ARITY2;
+    use crate::poseidon::POSEIDON_HASH_PARAM_BLS12_381_NEW_SCALAR_ARITY2;
     use ark_poly_commit::PolynomialCommitment;
     use ark_std::test_rng;
     use plonk_core::circuit::{verify_proof, VerifierData};
@@ -89,7 +89,7 @@ fn action_circuit_test() {
     let spend_info = SpendInfo::<CP>::new(
         spend_note,
         merkle_path,
-        &POSEIDON_HASH_PARAM_BLS12_377_SCALAR_ARITY2,
+        &POSEIDON_HASH_PARAM_BLS12_381_NEW_SCALAR_ARITY2,
     );
 
     let output_info = OutputInfo::<CP>::dummy(&mut rng);

--- a/src/circuit/blinding_circuit.rs
+++ b/src/circuit/blinding_circuit.rs
@@ -6,6 +6,7 @@ use ark_ff::UniformRand;
 use ark_ff::{BigInteger, PrimeField};
 use ark_poly::univariate::DensePolynomial;
 use ark_poly_commit::PolynomialCommitment;
+
 use plonk_core::{
     circuit::Circuit, constraint_system::StandardComposer, prelude::Error, prelude::Variable,
     proof_system::Blinding,
@@ -95,6 +96,7 @@ where
         // TODO: Constrain com_vp
 
         println!("circuit size: {}", composer.circuit_bound());
+        composer.check_circuit_satisfied();
         Ok(())
     }
 
@@ -126,4 +128,98 @@ impl<CP: CircuitParameters> BlindingCircuit<CP> {
     pub fn get_blinding(&self) -> Blinding<CP::CurveScalarField> {
         self.blinding
     }
+}
+
+#[ignore]
+#[test]
+fn test_blinding_circuit() {
+    // creation of a (balance) VP
+    // creation of the corresponding blinding circuit
+    // checking the blinding circuit
+
+    use crate::circuit::circuit_parameters::PairingCircuitParameters as CP;
+    use crate::circuit::validity_predicate::NUM_NOTE;
+    use crate::circuit::vp_examples::balance::BalanceValidityPredicate;
+    use crate::note::Note;
+    use crate::utils::ws_to_te;
+    use crate::vp_description::ValidityPredicateDescription;
+    use plonk_core::circuit::{verify_proof, VerifierData};
+    use plonk_core::proof_system::pi::PublicInputs;
+    type Fr = <CP as CircuitParameters>::CurveScalarField;
+    type Fq = <CP as CircuitParameters>::CurveBaseField;
+    type P = <CP as CircuitParameters>::InnerCurve;
+    type OP = <CP as CircuitParameters>::Curve;
+    type PC = <CP as CircuitParameters>::CurvePC;
+    type Opc = <CP as CircuitParameters>::OuterCurvePC;
+    use ark_std::test_rng;
+
+    let mut rng = test_rng();
+
+    // A balance VP
+    let input_notes = [(); NUM_NOTE].map(|_| Note::<CP>::dummy(&mut rng));
+    let output_notes = input_notes.clone();
+    let mut balance_vp = BalanceValidityPredicate::new(input_notes, output_notes);
+    balance_vp
+        .gadget(&mut StandardComposer::<Fr, P>::new())
+        .unwrap();
+
+    // we blind the VP desc
+    let pp = PC::setup(balance_vp.padded_circuit_size(), None, &mut rng).unwrap();
+    let vp_desc = ValidityPredicateDescription::from_vp(&mut balance_vp, &pp).unwrap();
+    let vp_desc_compressed = vp_desc.get_compress();
+
+    // the blinding circuit, containing the random values used to blind
+    let mut blinding_circuit =
+        BlindingCircuit::<CP>::new(&mut rng, vp_desc, &pp, balance_vp.padded_circuit_size())
+            .unwrap();
+
+    // verifying key with the blinding
+    let (_, vk_blind) = balance_vp
+        .compile_with_blinding::<PC>(&pp, &blinding_circuit.get_blinding())
+        .unwrap();
+
+    let blinding_circuit_size = blinding_circuit.padded_circuit_size();
+    let pp_blind = Opc::setup(blinding_circuit_size, None, &mut rng).unwrap();
+
+    let (pk_p, vk) = blinding_circuit.compile::<Opc>(&pp_blind).unwrap();
+
+    // Blinding Prover
+    let (proof, pi) = blinding_circuit
+        .gen_proof::<Opc>(&pp_blind, pk_p, b"Test")
+        .unwrap();
+
+    // Expecting vk_blind(out of circuit)
+    let mut expect_pi = PublicInputs::new(blinding_circuit_size);
+    let q_m = ws_to_te(vk_blind.arithmetic.q_m.0);
+    expect_pi.insert(392, q_m.x);
+    expect_pi.insert(393, q_m.y);
+    let q_l = ws_to_te(vk_blind.arithmetic.q_l.0);
+    expect_pi.insert(782, q_l.x);
+    expect_pi.insert(783, q_l.y);
+    let q_r = ws_to_te(vk_blind.arithmetic.q_r.0);
+    expect_pi.insert(1172, q_r.x);
+    expect_pi.insert(1173, q_r.y);
+    let q_o = ws_to_te(vk_blind.arithmetic.q_o.0);
+    expect_pi.insert(1562, q_o.x);
+    expect_pi.insert(1563, q_o.y);
+    let q_4 = ws_to_te(vk_blind.arithmetic.q_4.0);
+    expect_pi.insert(1952, q_4.x);
+    expect_pi.insert(1953, q_4.y);
+    let q_c = ws_to_te(vk_blind.arithmetic.q_c.0);
+    expect_pi.insert(2342, q_c.x);
+    expect_pi.insert(2343, q_c.y);
+    expect_pi.insert(21388, vp_desc_compressed);
+
+    assert_eq!(pi, expect_pi);
+
+    // Blinding Verifier
+    let verifier_data = VerifierData::new(vk, pi);
+    verify_proof::<Fq, OP, Opc>(
+        &pp_blind,
+        verifier_data.key,
+        &proof,
+        &verifier_data.pi,
+        b"Test",
+    )
+    .unwrap();
 }

--- a/src/circuit/circuit_parameters.rs
+++ b/src/circuit/circuit_parameters.rs
@@ -71,15 +71,15 @@ pub trait CircuitParameters: Copy {
 pub struct PairingCircuitParameters {}
 
 impl CircuitParameters for PairingCircuitParameters {
-    type CurveScalarField = ark_bls12_377::Fr;
-    type CurveBaseField = ark_bls12_377::Fq;
-    type Curve = ark_bls12_377::g1::Parameters;
-    type InnerCurveScalarField = ark_ed_on_bls12_377::Fr;
-    type InnerCurve = ark_ed_on_bls12_377::EdwardsParameters;
-    type OuterCurveBaseField = ark_bw6_761::Fq;
-    type OuterCurve = ark_bw6_761::g1::Parameters;
-    type CurvePC = KZG10<ark_bls12_377::Bls12_377>;
-    type OuterCurvePC = KZG10<ark_bw6_761::BW6_761>;
+    type CurveScalarField = ark_bls12_381_new::Fr;
+    type CurveBaseField = ark_bls12_381_new::Fq;
+    type Curve = ark_bls12_381_new::g1::Parameters;
+    type InnerCurveScalarField = ark_ed_on_bls12_381_new::Fr;
+    type InnerCurve = ark_ed_on_bls12_381_new::Parameters;
+    type OuterCurveBaseField = ark_bw6_764_new::Fq;
+    type OuterCurve = ark_bw6_764_new::g1::Parameters;
+    type CurvePC = KZG10<ark_bls12_381_new::Bls12_381New>;
+    type OuterCurvePC = KZG10<ark_bw6_764_new::BW6_764New>;
 
     fn pack_vk(
         vk: &VerifierKey<Self::CurveScalarField, Self::CurvePC>,
@@ -123,12 +123,11 @@ impl CircuitParameters for PairingCircuitParameters {
         vp_circuit_size: usize,
     ) -> [Self::CurveBaseField; 2] {
         let (ck, _) = Self::CurvePC::trim(vp_setup, vp_circuit_size, 0, None).unwrap();
-
-        // [b * Z_H + q] ?= b *[Z_H] + [q]
         let n = ck.powers_of_g.len();
         let com_g_n = ck.powers_of_g[n - 1];
         let com_g_0 = ck.powers_of_g[0];
-        let com_z_h = ws_to_te(com_g_n + com_g_0.neg());
+        let ws_com_zh = com_g_n + com_g_0.neg();
+        let com_z_h = ws_to_te(ws_com_zh);
         [com_z_h.x, com_z_h.y]
     }
 }

--- a/src/circuit/gadgets.rs
+++ b/src/circuit/gadgets.rs
@@ -1,4 +1,6 @@
 pub mod field_addition;
 pub mod hash;
 pub mod merkle_tree;
+pub mod point_addition;
+pub mod scalar_multiplication;
 pub mod trivial;

--- a/src/circuit/gadgets/merkle_tree.rs
+++ b/src/circuit/gadgets/merkle_tree.rs
@@ -49,7 +49,7 @@ fn test_merkle_circuit() {
     use crate::circuit::circuit_parameters::{CircuitParameters, PairingCircuitParameters};
     use crate::merkle_tree::TAIGA_COMMITMENT_TREE_DEPTH;
     use crate::merkle_tree::{MerklePath, Node};
-    use crate::poseidon::POSEIDON_HASH_PARAM_BLS12_377_SCALAR_ARITY2;
+    use crate::poseidon::POSEIDON_HASH_PARAM_BLS12_381_NEW_SCALAR_ARITY2;
     type Fr = <PairingCircuitParameters as CircuitParameters>::CurveScalarField;
     type P = <PairingCircuitParameters as CircuitParameters>::InnerCurve;
     use ark_std::test_rng;
@@ -63,7 +63,7 @@ fn test_merkle_circuit() {
     let expected = merkle_path
         .root(
             cur_leaf.clone(),
-            &POSEIDON_HASH_PARAM_BLS12_377_SCALAR_ARITY2,
+            &POSEIDON_HASH_PARAM_BLS12_381_NEW_SCALAR_ARITY2,
         )
         .unwrap();
 
@@ -73,7 +73,7 @@ fn test_merkle_circuit() {
         &mut composer,
         &commitment,
         &merkle_path.get_path(),
-        &POSEIDON_HASH_PARAM_BLS12_377_SCALAR_ARITY2,
+        &POSEIDON_HASH_PARAM_BLS12_381_NEW_SCALAR_ARITY2,
     )
     .unwrap();
     composer.check_circuit_satisfied();

--- a/src/circuit/gadgets/point_addition.rs
+++ b/src/circuit/gadgets/point_addition.rs
@@ -1,0 +1,65 @@
+use ark_ec::TEModelParameters;
+use ark_ff::PrimeField;
+use plonk_core::prelude::{Point, StandardComposer};
+
+pub fn point_addition_gadget<F: PrimeField, P: TEModelParameters<BaseField = F>>(
+    composer: &mut StandardComposer<F, P>,
+    var_a: Point<P>,
+    var_b: Point<P>,
+) -> Point<P> {
+    // simple circuit for the computaiton of a+b (and return the variable corresponding to c=a+b).
+    composer.point_addition_gate(var_a, var_b)
+}
+
+#[test]
+fn test_point_addition_gadget() {
+    use crate::circuit::circuit_parameters::{CircuitParameters, PairingCircuitParameters as CP};
+    use ark_ec::twisted_edwards_extended::GroupAffine as TEGroupAffine;
+    use ark_ec::TEModelParameters;
+
+    // Test over InnerCurve
+    type PC = <CP as CircuitParameters>::CurvePC;
+    type F = <CP as CircuitParameters>::CurveScalarField;
+    type P = <CP as CircuitParameters>::InnerCurve;
+
+    // Points
+    let (x, y) = P::AFFINE_GENERATOR_COEFFS;
+    let generator = TEGroupAffine::<P>::new(x, y);
+    let expected_point = generator + generator;
+
+    // gadget
+    let mut composer = StandardComposer::<
+        <CP as CircuitParameters>::CurveScalarField,
+        <CP as CircuitParameters>::InnerCurve,
+    >::new();
+    let x_var = composer.add_input(x);
+    let y_var = composer.add_input(y);
+    let point_a: Point<P> = Point::new(x_var, y_var);
+    let point_b: Point<P> = Point::new(x_var, y_var);
+    let point = composer.point_addition_gate(point_a, point_b);
+    composer.assert_equal_public_point(point, expected_point);
+    composer.check_circuit_satisfied();
+
+    // Test over Curve
+    type Opc = <CP as CircuitParameters>::OuterCurvePC;
+    type Fq = <CP as CircuitParameters>::CurveBaseField;
+    type OP = <CP as CircuitParameters>::Curve;
+
+    // Points
+    let (x, y) = OP::AFFINE_GENERATOR_COEFFS;
+    let generator = TEGroupAffine::<OP>::new(x, y);
+    let expected_point = generator + generator;
+
+    // gadget
+    let mut composer = StandardComposer::<
+        <CP as CircuitParameters>::CurveBaseField,
+        <CP as CircuitParameters>::Curve,
+    >::new();
+    let x_var = composer.add_input(x);
+    let y_var = composer.add_input(y);
+    let point_a: Point<OP> = Point::new(x_var, y_var);
+    let point_b: Point<OP> = Point::new(x_var, y_var);
+    let point = composer.point_addition_gate(point_a, point_b);
+    composer.assert_equal_public_point(point, expected_point);
+    composer.check_circuit_satisfied();
+}

--- a/src/circuit/gadgets/scalar_multiplication.rs
+++ b/src/circuit/gadgets/scalar_multiplication.rs
@@ -1,0 +1,79 @@
+use ark_ec::twisted_edwards_extended::GroupAffine as TEGroupAffine;
+use ark_ec::TEModelParameters;
+use ark_ff::PrimeField;
+use plonk_core::{
+    constraint_system::Variable,
+    prelude::{Point, StandardComposer},
+};
+
+pub fn scalar_multiplication_gadget<F: PrimeField, P: TEModelParameters<BaseField = F>>(
+    composer: &mut StandardComposer<F, P>,
+    var_n: Variable,
+) -> Point<P> {
+    // simple circuit for the computaiton of [n] * a (and return the variable corresponding to b=[n]a).
+    let (x, y) = P::AFFINE_GENERATOR_COEFFS;
+    let generator = TEGroupAffine::<P>::new(x, y);
+    composer.fixed_base_scalar_mul(var_n, generator)
+}
+
+#[test]
+fn test_scalar_multiplication_gadget() {
+    use crate::circuit::circuit_parameters::{CircuitParameters, PairingCircuitParameters as CP};
+    use ark_ec::twisted_edwards_extended::GroupAffine as TEGroupAffine;
+    use ark_ec::TEModelParameters;
+
+    type PC = <CP as CircuitParameters>::CurvePC;
+    type F = <CP as CircuitParameters>::CurveScalarField;
+    type P = <CP as CircuitParameters>::InnerCurve;
+    type Opc = <CP as CircuitParameters>::OuterCurvePC;
+    type Fq = <CP as CircuitParameters>::CurveBaseField;
+    type OP = <CP as CircuitParameters>::Curve;
+    use ark_poly_commit::PolynomialCommitment;
+    use plonk_core::proof_system::Prover;
+    use plonk_core::proof_system::Verifier;
+    use rand::rngs::OsRng;
+
+    // Points
+    let (x, y) = OP::AFFINE_GENERATOR_COEFFS;
+    let generator = TEGroupAffine::<OP>::new(x, y);
+    let scalar = Fq::from(3);
+    let expected_point = generator + generator + generator;
+
+    // public params
+    let u_params = Opc::setup(512, None, &mut OsRng).unwrap();
+
+    // Commit Key
+    let (ck, vk) = Opc::trim(&u_params, 512, 0, None).unwrap();
+
+    // prover
+    let mut prover: Prover<Fq, OP, Opc> = Prover::new(b"demo");
+
+    // gadget
+    let composer_prover = prover.mut_cs();
+    let var_n = composer_prover.add_input(scalar);
+    let point = composer_prover.fixed_base_scalar_mul(var_n, generator);
+    composer_prover.assert_equal_public_point(point, expected_point);
+    composer_prover.check_circuit_satisfied();
+
+    // Preprocess circuit
+    prover.preprocess(&ck).unwrap();
+
+    let public_inputs = prover.cs.get_pi().clone();
+
+    let proof = prover.prove(&ck).unwrap();
+
+    // Verifier
+    let mut verifier = Verifier::<Fq, OP, Opc>::new(b"demo");
+
+    // Verifier gadget
+    let composer_verifier = verifier.mut_cs();
+    let var_n = composer_verifier.add_input(scalar);
+    let point = composer_verifier.fixed_base_scalar_mul(var_n, generator);
+    composer_verifier.assert_equal_public_point(point, expected_point);
+    composer_verifier.check_circuit_satisfied();
+
+    // // Preprocess
+    verifier.preprocess(&ck).unwrap();
+
+    assert!(verifier.verify(&proof, &vk, &public_inputs).is_ok());
+}

--- a/src/circuit/vp_examples.rs
+++ b/src/circuit/vp_examples.rs
@@ -1,4 +1,6 @@
 pub mod balance;
 pub mod field_addition;
+pub mod point_addition;
+pub mod scalar_multiplication;
 pub mod white_list_senders;
 pub mod white_list_tokens;

--- a/src/circuit/vp_examples/white_list_senders.rs
+++ b/src/circuit/vp_examples/white_list_senders.rs
@@ -41,7 +41,8 @@ where
         output_note_variables: &[ValidityPredicateOuputNoteVariables],
     ) -> Result<(), Error> {
         let expected_var = composer.add_input(self.mk_root.inner());
-        let poseidon_hash_param_bls12_377_scalar_arity2 = PoseidonConstants::generate::<WIDTH_3>();
+        let poseidon_hash_param_bls12_381_new_scalar_arity2 =
+            PoseidonConstants::generate::<WIDTH_3>();
         for (output_note_variable, path) in output_note_variables.iter().zip(self.paths.clone()) {
             let owner_var = output_note_variable.recipient_addr;
             let root_var = merkle_tree_gadget::<
@@ -52,7 +53,7 @@ where
                 composer,
                 &owner_var,
                 &path.get_path(),
-                &poseidon_hash_param_bls12_377_scalar_arity2,
+                &poseidon_hash_param_bls12_381_new_scalar_arity2,
             )
             .unwrap();
             composer.assert_equal(expected_var, root_var);
@@ -80,18 +81,19 @@ where
     }
 }
 
+#[ignore]
 #[test]
 fn test_white_list_senders_vp_example() {
     use crate::circuit::circuit_parameters::PairingCircuitParameters as CP;
     use crate::merkle_tree::MerkleTreeLeafs;
     use crate::poseidon::WIDTH_3;
+    use ark_poly_commit::PolynomialCommitment;
     use ark_std::test_rng;
+    use plonk_core::circuit::{verify_proof, VerifierData};
 
     type Fr = <CP as CircuitParameters>::CurveScalarField;
     type P = <CP as CircuitParameters>::InnerCurve;
     type PC = <CP as CircuitParameters>::CurvePC;
-    // use ark_poly_commit::PolynomialCommitment;
-    // use plonk_core::circuit::{verify_proof, VerifierData};
 
     let mut rng = test_rng();
     let input_notes = [(); NUM_NOTE].map(|_| Note::<CP>::dummy(&mut rng));
@@ -117,10 +119,10 @@ fn test_white_list_senders_vp_example() {
         .map(|v| v.address().unwrap())
         .collect();
 
-    let poseidon_hash_param_bls12_377_scalar_arity2 = PoseidonConstants::generate::<WIDTH_3>();
+    let poseidon_hash_param_bls12_381_new_scalar_arity2 = PoseidonConstants::generate::<WIDTH_3>();
     let mk_root =
         MerkleTreeLeafs::<Fr, PoseidonConstants<Fr>>::new(white_list_senders_to_fields.to_vec())
-            .root(&poseidon_hash_param_bls12_377_scalar_arity2);
+            .root(&poseidon_hash_param_bls12_381_new_scalar_arity2);
 
     let paths: Vec<MerklePath<Fr, PoseidonConstants<Fr>>> = vec![
         MerklePath::build_merkle_path(&white_list_senders_to_fields, 7),
@@ -145,18 +147,18 @@ fn test_white_list_senders_vp_example() {
         composer.circuit_bound()
     );
 
-    // // Generate CRS
-    // let pp = PC::setup(white_list_senders_vp.padded_circuit_size(), None, &mut rng).unwrap();
+    // Generate CRS
+    let pp = PC::setup(white_list_senders_vp.padded_circuit_size(), None, &mut rng).unwrap();
 
-    // // Compile the circuit
-    // let (pk_p, vk) = white_list_senders_vp.compile::<PC>(&pp).unwrap();
+    // Compile the circuit
+    let (pk_p, vk) = white_list_senders_vp.compile::<PC>(&pp).unwrap();
 
-    // // Prover
-    // let (proof, pi) = white_list_senders_vp
-    //     .gen_proof::<PC>(&pp, pk_p, b"Test")
-    //     .unwrap();
+    // Prover
+    let (proof, pi) = white_list_senders_vp
+        .gen_proof::<PC>(&pp, pk_p, b"Test")
+        .unwrap();
 
-    // // Verifier
-    // let verifier_data = VerifierData::new(vk, pi);
-    // verify_proof::<Fr, P, PC>(&pp, verifier_data.key, &proof, &verifier_data.pi, b"Test").unwrap();
+    // Verifier
+    let verifier_data = VerifierData::new(vk, pi);
+    verify_proof::<Fr, P, PC>(&pp, verifier_data.key, &proof, &verifier_data.pi, b"Test").unwrap();
 }

--- a/src/circuit/vp_examples/white_list_tokens.rs
+++ b/src/circuit/vp_examples/white_list_tokens.rs
@@ -41,7 +41,8 @@ where
         output_note_variables: &[ValidityPredicateOuputNoteVariables],
     ) -> Result<(), Error> {
         let expected_var = composer.add_input(self.mk_root.inner());
-        let poseidon_hash_param_bls12_377_scalar_arity2 = PoseidonConstants::generate::<WIDTH_3>();
+        let poseidon_hash_param_bls12_381_new_scalar_arity2 =
+            PoseidonConstants::generate::<WIDTH_3>();
         for (output_note_variable, path) in output_note_variables.iter().zip(self.paths.clone()) {
             let token_var = output_note_variable.token_addr;
             let root_var = merkle_tree_gadget::<
@@ -52,7 +53,7 @@ where
                 composer,
                 &token_var,
                 &path.get_path(),
-                &poseidon_hash_param_bls12_377_scalar_arity2,
+                &poseidon_hash_param_bls12_381_new_scalar_arity2,
             )
             .unwrap();
             composer.assert_equal(expected_var, root_var);
@@ -80,8 +81,12 @@ where
     }
 }
 
+#[ignore]
 #[test]
 fn test_white_list_tokens_vp_example() {
+    use ark_poly_commit::PolynomialCommitment;
+    use plonk_core::circuit::{verify_proof, VerifierData};
+
     use crate::circuit::circuit_parameters::PairingCircuitParameters as CP;
     use crate::merkle_tree::MerkleTreeLeafs;
     use crate::poseidon::WIDTH_3;
@@ -90,8 +95,6 @@ fn test_white_list_tokens_vp_example() {
     type Fr = <CP as CircuitParameters>::CurveScalarField;
     type P = <CP as CircuitParameters>::InnerCurve;
     type PC = <CP as CircuitParameters>::CurvePC;
-    // use ark_poly_commit::PolynomialCommitment;
-    // use plonk_core::circuit::{verify_proof, VerifierData};
 
     let mut rng = test_rng();
     let input_notes = [(); NUM_NOTE].map(|_| Note::<CP>::dummy(&mut rng));
@@ -115,10 +118,10 @@ fn test_white_list_tokens_vp_example() {
         .map(|v| v.address().unwrap())
         .collect();
 
-    let poseidon_hash_param_bls12_377_scalar_arity2 = PoseidonConstants::generate::<WIDTH_3>();
+    let poseidon_hash_param_bls12_381_new_scalar_arity2 = PoseidonConstants::generate::<WIDTH_3>();
     let mk_root =
         MerkleTreeLeafs::<Fr, PoseidonConstants<Fr>>::new(white_list_tokens_to_fields.to_vec())
-            .root(&poseidon_hash_param_bls12_377_scalar_arity2);
+            .root(&poseidon_hash_param_bls12_381_new_scalar_arity2);
 
     let paths: Vec<MerklePath<Fr, PoseidonConstants<Fr>>> = vec![
         MerklePath::build_merkle_path(&white_list_tokens_to_fields, 7),
@@ -142,18 +145,18 @@ fn test_white_list_tokens_vp_example() {
         composer.circuit_bound()
     );
 
-    // // Generate CRS
-    // let pp = PC::setup(white_list_tokens_vp.padded_circuit_size(), None, &mut rng).unwrap();
+    // Generate CRS
+    let pp = PC::setup(white_list_tokens_vp.padded_circuit_size(), None, &mut rng).unwrap();
 
-    // // Compile the circuit
-    // let (pk_p, vk) = white_list_tokens_vp.compile::<PC>(&pp).unwrap();
+    // Compile the circuit
+    let (pk_p, vk) = white_list_tokens_vp.compile::<PC>(&pp).unwrap();
 
-    // // Prover
-    // let (proof, pi) = white_list_tokens_vp
-    //     .gen_proof::<PC>(&pp, pk_p, b"Test")
-    //     .unwrap();
+    // Prover
+    let (proof, pi) = white_list_tokens_vp
+        .gen_proof::<PC>(&pp, pk_p, b"Test")
+        .unwrap();
 
-    // // Verifier
-    // let verifier_data = VerifierData::new(vk, pi);
-    // verify_proof::<Fr, P, PC>(&pp, verifier_data.key, &proof, &verifier_data.pi, b"Test").unwrap();
+    // Verifier
+    let verifier_data = VerifierData::new(vk, pi);
+    verify_proof::<Fr, P, PC>(&pp, verifier_data.key, &proof, &verifier_data.pi, b"Test").unwrap();
 }

--- a/src/el_gamal.rs
+++ b/src/el_gamal.rs
@@ -126,10 +126,10 @@ impl<C: TEModelParameters> EncryptionKey<C> {
 
 #[test]
 fn test_el_gamal() {
-    use ark_pallas::PallasParameters;
+    use ark_bls12_381_new::g1::Parameters;
 
     let mut rng = rand::thread_rng();
-    let dk = DecryptionKey::<PallasParameters>::new(&mut rng);
+    let dk = DecryptionKey::<Parameters>::new(&mut rng);
     let ek = dk.encryption_key();
 
     let msg = "JeMAppelleSimon.................".as_bytes();

--- a/src/poseidon.rs
+++ b/src/poseidon.rs
@@ -12,16 +12,16 @@ pub const WIDTH_3: usize = 3;
 pub const WIDTH_5: usize = 5;
 pub const WIDTH_9: usize = 9;
 lazy_static! {
-    pub static ref POSEIDON_HASH_PARAM_BLS12_377_SCALAR_ARITY2: PoseidonConstants<ark_bls12_377::Fr> =
+    pub static ref POSEIDON_HASH_PARAM_BLS12_381_NEW_SCALAR_ARITY2: PoseidonConstants<ark_bls12_381_new::Fr> =
         PoseidonConstants::generate::<WIDTH_3>();
-    pub static ref POSEIDON_HASH_PARAM_BLS12_377_SCALAR_ARITY4: PoseidonConstants<ark_bls12_377::Fr> =
+    pub static ref POSEIDON_HASH_PARAM_BLS12_381_NEW_SCALAR_ARITY4: PoseidonConstants<ark_bls12_381_new::Fr> =
         PoseidonConstants::generate::<WIDTH_5>();
 
-    // Hashes of bls12_377::BaseField are generated automatically, not tested yet.
+    // Hashes of bls12_381_new::BaseField are generated automatically, not tested yet.
     // Especially we need to check the round number generation from the paper.
-    pub static ref POSEIDON_HASH_PARAM_BLS12_377_BASE_ARITY2: PoseidonConstants<ark_bls12_377::Fq> =
+    pub static ref POSEIDON_HASH_PARAM_BLS12_381_NEW_BASE_ARITY2: PoseidonConstants<ark_bls12_381_new::Fq> =
         PoseidonConstants::generate::<WIDTH_3>();
-    pub static ref POSEIDON_HASH_PARAM_BLS12_377_BASE_ARITY4: PoseidonConstants<ark_bls12_377::Fq> =
+    pub static ref POSEIDON_HASH_PARAM_BLS12_381_NEW_BASE_ARITY4: PoseidonConstants<ark_bls12_381_new::Fq> =
         PoseidonConstants::generate::<WIDTH_5>();
 }
 
@@ -58,15 +58,15 @@ fn test_poseidon_circuit_example() {
     use ark_ec::PairingEngine;
     use ark_std::{test_rng, UniformRand};
     use plonk_hashing::poseidon::poseidon::{NativeSpec, PlonkSpec, Poseidon};
-    type E = ark_bls12_377::Bls12_377;
-    type P = ark_ed_on_bls12_377::EdwardsParameters;
+    type E = ark_bls12_381_new::Bls12_381New;
+    type P = ark_ed_on_bls12_381_new::Parameters;
     type Fr = <E as PairingEngine>::Fr;
     use plonk_core::constraint_system::StandardComposer;
 
     let mut rng = test_rng();
     let mut poseidon_native = Poseidon::<(), NativeSpec<Fr, WIDTH_3>, WIDTH_3>::new(
         &mut (),
-        &POSEIDON_HASH_PARAM_BLS12_377_SCALAR_ARITY2,
+        &POSEIDON_HASH_PARAM_BLS12_381_NEW_SCALAR_ARITY2,
     );
     let inputs = (0..(WIDTH_3 - 1))
         .map(|_| Fr::rand(&mut rng))
@@ -81,7 +81,7 @@ fn test_poseidon_circuit_example() {
     let inputs_var = inputs.iter().map(|x| c.add_input(*x)).collect::<Vec<_>>();
     let mut poseidon_circuit = Poseidon::<_, PlonkSpec<WIDTH_3>, WIDTH_3>::new(
         &mut c,
-        &POSEIDON_HASH_PARAM_BLS12_377_SCALAR_ARITY2,
+        &POSEIDON_HASH_PARAM_BLS12_381_NEW_SCALAR_ARITY2,
     );
     inputs_var.iter().for_each(|x| {
         let _ = poseidon_circuit.input(*x).unwrap();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,4 @@
-use ark_bls12_377::Fq;
+use ark_bls12_381_new::Fq;
 use ark_ec::{
     short_weierstrass_jacobian::GroupAffine as SWGroupAffine,
     twisted_edwards_extended::GroupAffine as TEGroupAffine,
@@ -11,17 +11,59 @@ pub fn bits_to_fields<F: PrimeField>(bits: &[bool]) -> Vec<F> {
         .collect()
 }
 
-// warning! Works only for bls12_377
+// warning! Works only for bls12_381_new
 pub fn ws_to_te(
-    p: SWGroupAffine<ark_bls12_377::g1::Parameters>,
-) -> TEGroupAffine<ark_bls12_377::g1::Parameters> {
-    // values available in https://github.com/arkworks-rs/curves/blob/master/bls12_377/src/curves/g1.rs
-    let x = p.x;
-    let y = p.y;
+    p: SWGroupAffine<ark_bls12_381_new::g1::Parameters>,
+) -> TEGroupAffine<ark_bls12_381_new::g1::Parameters> {
+    /*
+    Wikipedia provides a WS->M and M->TE conversion.
+    Here we provide the WS -> TE conversion with few simpliciations.
+
+    (a and b are coefficients of the curve)
+    α = sqrt(x**3+a*x+b)
+    s1 = sqrt(3*α**2+a)
+    s2 = sqrt(-3*α-2*s1)
+    coeff = -(3*α-2*s1)/(3*α+2*s1)
+
+    u = (x-α) * s2 / y
+    v = (x-α-s1) / (x-α+s1)
+    (u,v) satisfies -u**2 + v**2 == 1 + coeff * u**2 * v**2
+
+
+    In the case of bls12_381_new:
+    α = -1
+    s1 = sqrt(3)
+    s2 = sqrt(-3+2*sqrt(3))
+    coeff = (-3-2*sqrt(3)) / (-3+2*sqrt(3))
+    u = (x+1) * s2 / y
+    v = (x+1-s1) / (x+1+s1)
+    */
     let alpha = -Fq::one();
-    let s = field_new!(Fq, "10189023633222963290707194929886294091415157242906428298294512798502806398782149227503530278436336312243746741931");
-    let sqrt_te1a = field_new!(Fq, "23560188534917577818843641916571445935985386319233886518929971599490231428764380923487987729215299304184915158756");
-    let x_te = (x - alpha) * sqrt_te1a / y;
-    let y_te = (s * (x - alpha) - Fq::one()) / (s * (x - alpha) + Fq::one());
-    TEGroupAffine::<ark_bls12_377::g1::Parameters>::new(x_te, y_te)
+    let s1 = field_new!(Fq, "611336158540232733028115263714465872671465435137168183916056024884978835858365189946006184892099852878171309395862");
+    // assert_eq!(s1*s1, Fq::from(3));
+    let s2 = field_new!(Fq, "1064881461568443305175032400733120695040834941031583268014086210056237636385831065297199936964360836443404508126238");
+    // assert_eq!(-s2*s2, s1+s1-Fq::from(3));
+    TEGroupAffine::<ark_bls12_381_new::g1::Parameters>::new(
+        (p.x - alpha) * s2 / p.y,
+        (p.x - alpha - s1) / (p.x - alpha + s1),
+    )
+}
+
+#[test]
+fn test_ws_to_te() {
+    use ark_bls12_381_new::g1;
+    use ark_bls12_381_new::g1::G1Projective;
+    use ark_ec::ProjectiveCurve;
+    use ark_ec::TEModelParameters;
+    use ark_std::UniformRand;
+    let mut rng = ark_std::test_rng();
+    for _ in 0..100 {
+        let p_ws: SWGroupAffine<g1::Parameters> = G1Projective::rand(&mut rng).into_affine();
+        let p_te = ws_to_te(p_ws);
+        let x = p_te.x;
+        let y = p_te.y;
+        let a = <g1::Parameters as TEModelParameters>::COEFF_A;
+        let d = <g1::Parameters as TEModelParameters>::COEFF_D;
+        assert_eq!(a * x * x + y * y, Fq::one() + d * x * x * y * y);
+    }
 }


### PR DESCRIPTION
* test for ws_to_te conversion

* change the curves and use my custom implem for the curve dependency

* wip before merging main

* move comment (minor change)

* add check_circuit_satisfied and some tests (removed from field_addition

* remove test_zh

* constructor for BalanceVP

* remove blinding circuit for field_addition

* forgotten poseidon changes

* asserts in comment for ws_to_te

* files for point addition circuit (not working)

* add classical_point_addition

* new bls12_381_new curve, revert point_addition_gate

* test for point addition is done in the gadget, the vp is disable for now because it doesn t work with the inner curve for now

* point addition gadget and VP work with the new curves, cleaning warnings

* use arkplonk branch taiga/randomized-circuits

* ws_to_te reverted with the new curve

* clippy fix

* scalar multiplication gadget and vp

* two tests for addition and scalar multiplication works

* ignore for cumbersome tests

Co-authored-by: Song Xuyang <xuyangsong@hotmail.com>