### PR TITLE
Simplify psi in note

### DIFF
--- a/taiga_halo2/src/action.rs
+++ b/taiga_halo2/src/action.rs
@@ -70,7 +70,7 @@ impl ActionInfo {
         ActionInfo::new(spend_info, output_info)
     }
 
-    pub fn build(self, rng: &mut impl RngCore) -> (ActionInstance, ActionCircuit) {
+    pub fn build<R: RngCore>(self, mut rng: R) -> (ActionInstance, ActionCircuit) {
         let nf = self.spend.note.get_nf();
 
         let user = User {
@@ -81,8 +81,17 @@ impl ActionInfo {
             app_vp: self.output.addr_app_vp,
         };
 
-        let note_rcm = pallas::Scalar::random(rng);
-        let output_note = Note::new(user, app, self.output.value, nf, self.output.data, note_rcm);
+        let psi = pallas::Base::random(&mut rng);
+        let note_rcm = pallas::Scalar::random(&mut rng);
+        let output_note = Note::new(
+            user,
+            app,
+            self.output.value,
+            nf,
+            self.output.data,
+            psi,
+            note_rcm,
+        );
 
         let output_cm = output_note.commitment();
         let action = ActionInstance {

--- a/taiga_halo2/src/circuit/note_circuit.rs
+++ b/taiga_halo2/src/circuit/note_circuit.rs
@@ -601,6 +601,7 @@ fn test_halo2_note_commitment_circuit() {
         value: u64,
         rho: Nullifier,
         data: pallas::Base,
+        psi: pallas::Base,
         rcm: pallas::Scalar,
     }
 
@@ -696,6 +697,7 @@ fn test_halo2_note_commitment_circuit() {
                 self.value,
                 self.rho,
                 self.data,
+                self.psi,
                 self.rcm,
             );
             // Construct a Sinsemilla chip
@@ -791,6 +793,7 @@ fn test_halo2_note_commitment_circuit() {
         value: rng.next_u64(),
         rho: Nullifier::default(),
         data: pallas::Base::random(&mut rng),
+        psi: pallas::Base::random(&mut rng),
         rcm: pallas::Scalar::random(&mut rng),
     };
 


### PR DESCRIPTION
In Orchard `cm = SinsemillaCommit(...|| rho || psi || value, rcm)`, `psi = prf([9] || rho || rseed)` and rcm = `prf([5] || rho || rseed)`.
I've removed the psi derivation from circuit and generated `psi` and `rcm` randomly for now.
Do we need to keep the `prf` derivation for `psi` and `rcm` like Orchard? It seems they can only transfer `rseed` in note-encryption instead of `psi` and `rcm`. Any other consideration?
Further, I didn't figure out why we need the `psi` here. If we remove `psi`, will we have any security problems?