### PR TITLE
application vp reorg

### DIFF
--- a/taiga_halo2/src/action.rs
+++ b/taiga_halo2/src/action.rs
@@ -6,9 +6,6 @@ use crate::{
     net_value_commitment::NetValueCommitment,
     note::{Note, NoteCommitment},
     nullifier::Nullifier,
-    user::User,
-    user::UserSendAddress,
-    vp_description::ValidityPredicateDescription,
 };
 use ff::Field;
 use pasta_curves::pallas;
@@ -49,10 +46,11 @@ pub struct SpendInfo {
 
 #[derive(Debug, Clone)]
 pub struct OutputInfo {
-    addr_send_closed: UserSendAddress,
-    addr_recv_vp: ValidityPredicateDescription,
-    app_vp: ValidityPredicateDescription,
-    app_data: pallas::Base,
+    app: App,
+    // addr_send_closed: UserSendAddress,
+    // addr_recv_vp: ValidityPredicateDescription,
+    // app_vp: ValidityPredicateDescription,
+    // app_data: pallas::Base,
     value: u64,
     is_normal: bool,
 }
@@ -88,18 +86,10 @@ impl ActionInfo {
 
     pub fn build<R: RngCore>(self, mut rng: R) -> (ActionInstance, ActionCircuit) {
         let nf = self.spend.note.get_nf();
-
-        let user = User {
-            send_com: self.output.addr_send_closed,
-            recv_vp: self.output.addr_recv_vp,
-        };
-        let app = App::new(self.output.app_vp, self.output.app_data);
-
         let psi = pallas::Base::random(&mut rng);
         let note_rcm = pallas::Scalar::random(&mut rng);
         let output_note = Note::new(
-            user,
-            app,
+            self.output.app,
             self.output.value,
             nf,
             psi,
@@ -149,19 +139,9 @@ impl SpendInfo {
 }
 
 impl OutputInfo {
-    pub fn new(
-        addr_send_closed: UserSendAddress,
-        addr_recv_vp: ValidityPredicateDescription,
-        app_vp: ValidityPredicateDescription,
-        app_data: pallas::Base,
-        value: u64,
-        is_normal: bool,
-    ) -> Self {
+    pub fn new(app: App, value: u64, is_normal: bool) -> Self {
         Self {
-            addr_send_closed,
-            addr_recv_vp,
-            app_vp,
-            app_data,
+            app,
             value,
             is_normal,
         }
@@ -169,16 +149,10 @@ impl OutputInfo {
 
     pub fn dummy<R: RngCore>(mut rng: R) -> Self {
         use rand::Rng;
-        let addr_send_closed = UserSendAddress::from_closed(pallas::Base::random(&mut rng));
-        let addr_recv_vp = ValidityPredicateDescription::dummy(&mut rng);
-        let app_vp = ValidityPredicateDescription::dummy(&mut rng);
-        let app_data = pallas::Base::random(&mut rng);
+        let app = App::dummy(&mut rng);
         let value: u64 = rng.gen();
         Self {
-            addr_send_closed,
-            addr_recv_vp,
-            app_vp,
-            app_data,
+            app,
             value,
             is_normal: true,
         }

--- a/taiga_halo2/src/action.rs
+++ b/taiga_halo2/src/action.rs
@@ -1,5 +1,5 @@
 use crate::{
-    app::App,
+    application::Application,
     circuit::action_circuit::ActionCircuit,
     constant::TAIGA_COMMITMENT_TREE_DEPTH,
     merkle_tree::{MerklePath, Node},
@@ -46,7 +46,7 @@ pub struct SpendInfo {
 
 #[derive(Debug, Clone)]
 pub struct OutputInfo {
-    app: App,
+    application: Application,
     // addr_send_closed: UserSendAddress,
     // addr_recv_vp: ValidityPredicateDescription,
     // app_vp: ValidityPredicateDescription,
@@ -89,7 +89,7 @@ impl ActionInfo {
         let psi = pallas::Base::random(&mut rng);
         let note_rcm = pallas::Scalar::random(&mut rng);
         let output_note = Note::new(
-            self.output.app,
+            self.output.application,
             self.output.value,
             nf,
             psi,
@@ -139,9 +139,9 @@ impl SpendInfo {
 }
 
 impl OutputInfo {
-    pub fn new(app: App, value: u64, is_normal: bool) -> Self {
+    pub fn new(application: Application, value: u64, is_normal: bool) -> Self {
         Self {
-            app,
+            application,
             value,
             is_normal,
         }
@@ -149,10 +149,10 @@ impl OutputInfo {
 
     pub fn dummy<R: RngCore>(mut rng: R) -> Self {
         use rand::Rng;
-        let app = App::dummy(&mut rng);
+        let application = Application::dummy(&mut rng);
         let value: u64 = rng.gen();
         Self {
-            app,
+            application,
             value,
             is_normal: true,
         }

--- a/taiga_halo2/src/action.rs
+++ b/taiga_halo2/src/action.rs
@@ -47,10 +47,6 @@ pub struct SpendInfo {
 #[derive(Debug, Clone)]
 pub struct OutputInfo {
     application: Application,
-    // addr_send_closed: UserSendAddress,
-    // addr_recv_vp: ValidityPredicateDescription,
-    // app_vp: ValidityPredicateDescription,
-    // app_data: pallas::Base,
     value: u64,
     is_normal: bool,
 }

--- a/taiga_halo2/src/app.rs
+++ b/taiga_halo2/src/app.rs
@@ -1,35 +1,50 @@
+use crate::user::{NullifierDerivingKey, User};
 use crate::vp_description::ValidityPredicateDescription;
 use ff::Field;
 use pasta_curves::pallas;
 use rand::RngCore;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct App {
     pub vp: ValidityPredicateDescription,
-    pub data: pallas::Base,
+    pub vp_data: pallas::Base,
+    user: User,
 }
 
 impl App {
-    pub fn new(vp: ValidityPredicateDescription, data: pallas::Base) -> Self {
-        Self { vp, data }
+    pub fn new(vp: ValidityPredicateDescription, vp_data: pallas::Base, user: User) -> Self {
+        Self { vp, vp_data, user }
     }
 
-    pub fn dummy(rng: &mut impl RngCore) -> Self {
+    pub fn dummy<R: RngCore>(mut rng: R) -> Self {
         Self {
-            vp: ValidityPredicateDescription::dummy(rng),
-            data: pallas::Base::random(rng),
+            vp: ValidityPredicateDescription::dummy(&mut rng),
+            vp_data: pallas::Base::random(&mut rng),
+            user: User::dummy(&mut rng),
         }
     }
 
     pub fn get_vp(&self) -> pallas::Base {
         self.vp.get_compressed()
     }
-}
 
-impl Default for App {
-    fn default() -> App {
-        let vp = ValidityPredicateDescription::Compressed(pallas::Base::one());
-        let data = pallas::Base::one();
-        App { vp, data }
+    pub fn get_user_send_closed(&self) -> pallas::Base {
+        self.user.get_send_closed()
+    }
+
+    pub fn get_user_send_data(&self) -> Option<pallas::Base> {
+        self.user.get_send_data()
+    }
+
+    pub fn get_user_recv_data(&self) -> pallas::Base {
+        self.user.get_recv_data()
+    }
+
+    pub fn get_user_address(&self) -> pallas::Base {
+        self.user.address()
+    }
+
+    pub fn get_nk(&self) -> Option<NullifierDerivingKey> {
+        self.user.get_nk()
     }
 }

--- a/taiga_halo2/src/application.rs
+++ b/taiga_halo2/src/application.rs
@@ -5,13 +5,13 @@ use pasta_curves::pallas;
 use rand::RngCore;
 
 #[derive(Debug, Clone, Default)]
-pub struct App {
+pub struct Application {
     pub vp: ValidityPredicateDescription,
     pub vp_data: pallas::Base,
     user: User,
 }
 
-impl App {
+impl Application {
     pub fn new(vp: ValidityPredicateDescription, vp_data: pallas::Base, user: User) -> Self {
         Self { vp, vp_data, user }
     }

--- a/taiga_halo2/src/application.rs
+++ b/taiga_halo2/src/application.rs
@@ -6,8 +6,8 @@ use rand::RngCore;
 
 #[derive(Debug, Clone, Default)]
 pub struct Application {
-    pub vp: ValidityPredicateDescription,
-    pub vp_data: pallas::Base,
+    vp: ValidityPredicateDescription,
+    vp_data: pallas::Base,
     user: User,
 }
 
@@ -26,6 +26,10 @@ impl Application {
 
     pub fn get_vp(&self) -> pallas::Base {
         self.vp.get_compressed()
+    }
+
+    pub fn get_vp_data(&self) -> pallas::Base {
+        self.vp_data
     }
 
     pub fn get_user_send_closed(&self) -> pallas::Base {

--- a/taiga_halo2/src/circuit/action_circuit.rs
+++ b/taiga_halo2/src/circuit/action_circuit.rs
@@ -205,7 +205,7 @@ impl Circuit<pallas::Base> for ActionCircuit {
             &self.auth_path,
         )?;
 
-        // TODO: user send address VP commitment and app VP commitment
+        // TODO: user send address VP commitment and application VP commitment
 
         // Output note
         let output_note_vars = check_output_note(
@@ -221,7 +221,7 @@ impl Circuit<pallas::Base> for ActionCircuit {
             ACTION_OUTPUT_CM_INSTANCE_ROW_IDX,
         )?;
 
-        // TODO: add user receive address VP commitment and app VP commitment
+        // TODO: add user receive address VP commitment and application VP commitment
 
         // TODO: add note verifiable encryption
 

--- a/taiga_halo2/src/circuit/integrity.rs
+++ b/taiga_halo2/src/circuit/integrity.rs
@@ -160,7 +160,7 @@ pub fn check_spend_note(
     let app_data = assign_free_advice(
         layouter.namespace(|| "witness app_vp_data"),
         advices[0],
-        Value::known(spend_note.application.vp_data),
+        Value::known(spend_note.application.get_vp_data()),
     )?;
 
     // Witness value(u64)
@@ -306,7 +306,7 @@ pub fn check_output_note(
     let app_data = assign_free_advice(
         layouter.namespace(|| "witness app_data"),
         advices[0],
-        Value::known(output_note.application.vp_data),
+        Value::known(output_note.application.get_vp_data()),
     )?;
 
     // Witness value(u64)

--- a/taiga_halo2/src/circuit/integrity.rs
+++ b/taiga_halo2/src/circuit/integrity.rs
@@ -99,28 +99,23 @@ pub fn check_spend_note(
 ) -> Result<SpendNoteVar, Error> {
     // Check spend note user integrity: user_address = Com_r(Com_r(send_vp, nk), recv_vp_hash)
     let (user_address, nk) = {
-        // Witness send_vp
-        let send_vp = spend_note
-            .user
-            .send_com
-            .get_send_vp()
-            .unwrap()
-            .get_compressed();
+        // Witness send_data
+        let send_data = spend_note.app.get_user_send_data().unwrap();
         let send_vp_var = assign_free_advice(
-            layouter.namespace(|| "witness nk"),
+            layouter.namespace(|| "witness user send data"),
             advices[0],
-            Value::known(send_vp),
+            Value::known(send_data),
         )?;
 
         // Witness nk
-        let nk = spend_note.user.get_nk().unwrap();
+        let nk = spend_note.app.get_nk().unwrap();
         let nk_var = assign_free_advice(
             layouter.namespace(|| "witness nk"),
             advices[0],
             Value::known(nk.inner()),
         )?;
 
-        // send_com = Com_r(send_vp, nk)
+        // send_com = Com_r(send_data, nk)
         let send_com = {
             let poseidon_chip = PoseidonChip::construct(poseidon_config.clone());
             let poseidon_hasher =
@@ -132,14 +127,14 @@ pub fn check_spend_note(
             poseidon_hasher.hash(layouter.namespace(|| "send_com"), poseidon_message)?
         };
 
-        // Witness recv_vp_hash
-        let recv_vp_hash_var = assign_free_advice(
-            layouter.namespace(|| "witness nk"),
+        // Witness recv_data
+        let recv_data = assign_free_advice(
+            layouter.namespace(|| "witness user recv data"),
             advices[0],
-            Value::known(spend_note.user.recv_vp.get_compressed()),
+            Value::known(spend_note.app.get_user_recv_data()),
         )?;
 
-        // user_address = Com_r(send_com, recv_vp_hash_var)
+        // user_address = Com_r(send_com, recv_vp_data)
         let user_address = {
             let poseidon_chip = PoseidonChip::construct(poseidon_config.clone());
             let poseidon_hasher =
@@ -147,7 +142,7 @@ pub fn check_spend_note(
                     poseidon_chip,
                     layouter.namespace(|| "Poseidon init"),
                 )?;
-            let poseidon_message = [send_com, recv_vp_hash_var];
+            let poseidon_message = [send_com, recv_data];
             poseidon_hasher.hash(layouter.namespace(|| "user_address"), poseidon_message)?
         };
 
@@ -163,9 +158,9 @@ pub fn check_spend_note(
 
     // Witness app_data
     let app_data = assign_free_advice(
-        layouter.namespace(|| "witness app_data"),
+        layouter.namespace(|| "witness app_vp_data"),
         advices[0],
-        Value::known(spend_note.app.data),
+        Value::known(spend_note.app.vp_data),
     )?;
 
     // Witness value(u64)
@@ -276,18 +271,18 @@ pub fn check_output_note(
     old_nf: AssignedCell<pallas::Base, pallas::Base>,
     cm_row_idx: usize,
 ) -> Result<OutputNoteVar, Error> {
-    // Check output note user integrity: user_address = Com_r(, recv_vp_hash)
+    // Check output note user integrity: user_address = Com_r(send_com, recv_vp_hash)
     let user_address = {
         let send_com = assign_free_advice(
             layouter.namespace(|| "witness output send_com"),
             advices[0],
-            Value::known(output_note.user.send_com.get_closed()),
+            Value::known(output_note.app.get_user_send_closed()),
         )?;
-        // Witness recv_vp_hash
-        let recv_vp_hash_var = assign_free_advice(
-            layouter.namespace(|| "witness nk"),
+        // Witness recv data
+        let recv_data = assign_free_advice(
+            layouter.namespace(|| "witness user recv data"),
             advices[0],
-            Value::known(output_note.user.recv_vp.get_compressed()),
+            Value::known(output_note.app.get_user_recv_data()),
         )?;
 
         let poseidon_chip = PoseidonChip::construct(poseidon_config);
@@ -296,7 +291,7 @@ pub fn check_output_note(
                 poseidon_chip,
                 layouter.namespace(|| "Poseidon init"),
             )?;
-        let poseidon_message = [send_com, recv_vp_hash_var];
+        let poseidon_message = [send_com, recv_data];
         poseidon_hasher.hash(layouter.namespace(|| "user_address"), poseidon_message)?
     };
 
@@ -311,7 +306,7 @@ pub fn check_output_note(
     let app_data = assign_free_advice(
         layouter.namespace(|| "witness app_data"),
         advices[0],
-        Value::known(output_note.app.data),
+        Value::known(output_note.app.vp_data),
     )?;
 
     // Witness value(u64)

--- a/taiga_halo2/src/circuit/integrity.rs
+++ b/taiga_halo2/src/circuit/integrity.rs
@@ -100,7 +100,7 @@ pub fn check_spend_note(
     // Check spend note user integrity: user_address = Com_r(Com_r(send_vp, nk), recv_vp_hash)
     let (user_address, nk) = {
         // Witness send_data
-        let send_data = spend_note.app.get_user_send_data().unwrap();
+        let send_data = spend_note.application.get_user_send_data().unwrap();
         let send_vp_var = assign_free_advice(
             layouter.namespace(|| "witness user send data"),
             advices[0],
@@ -108,7 +108,7 @@ pub fn check_spend_note(
         )?;
 
         // Witness nk
-        let nk = spend_note.app.get_nk().unwrap();
+        let nk = spend_note.application.get_nk().unwrap();
         let nk_var = assign_free_advice(
             layouter.namespace(|| "witness nk"),
             advices[0],
@@ -131,7 +131,7 @@ pub fn check_spend_note(
         let recv_data = assign_free_advice(
             layouter.namespace(|| "witness user recv data"),
             advices[0],
-            Value::known(spend_note.app.get_user_recv_data()),
+            Value::known(spend_note.application.get_user_recv_data()),
         )?;
 
         // user_address = Com_r(send_com, recv_vp_data)
@@ -153,14 +153,14 @@ pub fn check_spend_note(
     let app_vp = assign_free_advice(
         layouter.namespace(|| "witness app_vp"),
         advices[0],
-        Value::known(spend_note.app.get_vp()),
+        Value::known(spend_note.application.get_vp()),
     )?;
 
     // Witness app_data
     let app_data = assign_free_advice(
         layouter.namespace(|| "witness app_vp_data"),
         advices[0],
-        Value::known(spend_note.app.vp_data),
+        Value::known(spend_note.application.vp_data),
     )?;
 
     // Witness value(u64)
@@ -276,13 +276,13 @@ pub fn check_output_note(
         let send_com = assign_free_advice(
             layouter.namespace(|| "witness output send_com"),
             advices[0],
-            Value::known(output_note.app.get_user_send_closed()),
+            Value::known(output_note.application.get_user_send_closed()),
         )?;
         // Witness recv data
         let recv_data = assign_free_advice(
             layouter.namespace(|| "witness user recv data"),
             advices[0],
-            Value::known(output_note.app.get_user_recv_data()),
+            Value::known(output_note.application.get_user_recv_data()),
         )?;
 
         let poseidon_chip = PoseidonChip::construct(poseidon_config);
@@ -299,14 +299,14 @@ pub fn check_output_note(
     let app_vp = assign_free_advice(
         layouter.namespace(|| "witness app_vp"),
         advices[0],
-        Value::known(output_note.app.get_vp()),
+        Value::known(output_note.application.get_vp()),
     )?;
 
     // Witness app_data
     let app_data = assign_free_advice(
         layouter.namespace(|| "witness app_data"),
         advices[0],
-        Value::known(output_note.app.vp_data),
+        Value::known(output_note.application.vp_data),
     )?;
 
     // Witness value(u64)

--- a/taiga_halo2/src/circuit/note_circuit.rs
+++ b/taiga_halo2/src/circuit/note_circuit.rs
@@ -846,7 +846,7 @@ fn test_halo2_note_commitment_circuit() {
             let app_data = assign_free_advice(
                 layouter.namespace(|| "witness application vp_data"),
                 note_commit_config.advices[0],
-                Value::known(note.application.vp_data),
+                Value::known(note.application.get_vp_data()),
             )?;
 
             // Witness a random non-negative u64 note value

--- a/taiga_halo2/src/circuit/note_circuit.rs
+++ b/taiga_halo2/src/circuit/note_circuit.rs
@@ -490,7 +490,7 @@ pub fn note_commitment_gadget(
         [RangeConstrained::bitrange_of(user_address.value(), 0..250)],
     )?;
 
-    // `a` = (bits 250..=255 of user) || (bits 0..=4 of app)
+    // `a` = (bits 250..=255 of user) || (bits 0..=4 of application)
     let (a, user_tail_bit5, app_pre_bit5) = Decompose5_5::decompose(
         &lookup_config,
         chip.clone(),
@@ -499,7 +499,7 @@ pub fn note_commitment_gadget(
         &app_vp,
     )?;
 
-    // `app_5_254` = bits 5..=254 of `app`
+    // `app_5_254` = bits 5..=254 of `application`
     let app_5_254 = MessagePiece::from_subpieces(
         chip.clone(),
         layouter.namespace(|| "app_5_254"),
@@ -695,7 +695,7 @@ impl NoteChip {
 fn test_halo2_note_commitment_circuit() {
     use crate::circuit::gadgets::assign_free_advice;
     use crate::note::Note;
-    use crate::{app::App, nullifier::Nullifier, user::User};
+    use crate::{application::Application, nullifier::Nullifier, user::User};
     use ff::Field;
     use group::Curve;
     use halo2_gadgets::{
@@ -716,7 +716,7 @@ fn test_halo2_note_commitment_circuit() {
     #[derive(Default)]
     struct MyCircuit {
         user: User,
-        app: App,
+        application: Application,
         value: u64,
         rho: Nullifier,
         psi: pallas::Base,
@@ -811,7 +811,7 @@ fn test_halo2_note_commitment_circuit() {
                 NoteCommitmentFixedBases,
             >::load(note_commit_config.sinsemilla_config.clone(), &mut layouter)?;
             let note = Note::new(
-                self.app.clone(),
+                self.application.clone(),
                 self.value,
                 self.rho,
                 self.psi,
@@ -832,21 +832,21 @@ fn test_halo2_note_commitment_circuit() {
             let user_address = assign_free_advice(
                 layouter.namespace(|| "witness user address"),
                 note_commit_config.advices[0],
-                Value::known(note.app.get_user_address()),
+                Value::known(note.application.get_user_address()),
             )?;
 
-            // Witness app
+            // Witness application
             let app_vp = assign_free_advice(
                 layouter.namespace(|| "witness rho"),
                 note_commit_config.advices[0],
-                Value::known(note.app.get_vp()),
+                Value::known(note.application.get_vp()),
             )?;
 
             // Witness app_data
             let app_data = assign_free_advice(
-                layouter.namespace(|| "witness app vp_data"),
+                layouter.namespace(|| "witness application vp_data"),
                 note_commit_config.advices[0],
-                Value::known(note.app.vp_data),
+                Value::known(note.application.vp_data),
             )?;
 
             // Witness a random non-negative u64 note value
@@ -917,7 +917,7 @@ fn test_halo2_note_commitment_circuit() {
     {
         let circuit = MyCircuit {
             user: User::dummy(&mut rng),
-            app: App::dummy(&mut rng),
+            application: Application::dummy(&mut rng),
             value: rng.next_u64(),
             rho: Nullifier::default(),
             psi: pallas::Base::random(&mut rng),
@@ -933,7 +933,7 @@ fn test_halo2_note_commitment_circuit() {
     {
         let circuit = MyCircuit {
             user: User::dummy(&mut rng),
-            app: App::dummy(&mut rng),
+            application: Application::dummy(&mut rng),
             value: rng.next_u64(),
             rho: Nullifier::default(),
             psi: pallas::Base::random(&mut rng),

--- a/taiga_halo2/src/circuit/note_circuit.rs
+++ b/taiga_halo2/src/circuit/note_circuit.rs
@@ -811,7 +811,6 @@ fn test_halo2_note_commitment_circuit() {
                 NoteCommitmentFixedBases,
             >::load(note_commit_config.sinsemilla_config.clone(), &mut layouter)?;
             let note = Note::new(
-                self.user.clone(),
                 self.app.clone(),
                 self.value,
                 self.rho,
@@ -831,9 +830,9 @@ fn test_halo2_note_commitment_circuit() {
 
             // Witness user
             let user_address = assign_free_advice(
-                layouter.namespace(|| "witness rho"),
+                layouter.namespace(|| "witness user address"),
                 note_commit_config.advices[0],
-                Value::known(note.user.address()),
+                Value::known(note.app.get_user_address()),
             )?;
 
             // Witness app
@@ -845,9 +844,9 @@ fn test_halo2_note_commitment_circuit() {
 
             // Witness app_data
             let app_data = assign_free_advice(
-                layouter.namespace(|| "witness app app_data"),
+                layouter.namespace(|| "witness app vp_data"),
                 note_commit_config.advices[0],
-                Value::known(note.app.data),
+                Value::known(note.app.vp_data),
             )?;
 
             // Witness a random non-negative u64 note value

--- a/taiga_halo2/src/lib.rs
+++ b/taiga_halo2/src/lib.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::large_enum_variant)]
 
 pub mod action;
-pub mod app;
+pub mod application;
 pub mod circuit;
 pub mod constant;
 pub mod merkle_tree;

--- a/taiga_halo2/src/net_value_commitment.rs
+++ b/taiga_halo2/src/net_value_commitment.rs
@@ -41,6 +41,6 @@ pub fn derivate_value_base(is_normal: bool, app: &App) -> pallas::Point {
     let hash = pallas::Point::hash_to_curve("taiga:test");
     let mut bytes: Vec<u8> = vec![is_normal.into()];
     bytes.extend_from_slice(&app.get_vp().to_repr());
-    bytes.extend_from_slice(&app.data.to_repr());
+    bytes.extend_from_slice(&app.vp_data.to_repr());
     hash(&bytes)
 }

--- a/taiga_halo2/src/net_value_commitment.rs
+++ b/taiga_halo2/src/net_value_commitment.rs
@@ -41,6 +41,6 @@ pub fn derivate_value_base(is_normal: bool, application: &Application) -> pallas
     let hash = pallas::Point::hash_to_curve("taiga:test");
     let mut bytes: Vec<u8> = vec![is_normal.into()];
     bytes.extend_from_slice(&application.get_vp().to_repr());
-    bytes.extend_from_slice(&application.vp_data.to_repr());
+    bytes.extend_from_slice(&application.get_vp_data().to_repr());
     hash(&bytes)
 }

--- a/taiga_halo2/src/net_value_commitment.rs
+++ b/taiga_halo2/src/net_value_commitment.rs
@@ -1,4 +1,4 @@
-use crate::app::App;
+use crate::application::Application;
 use crate::constant::NOTE_COMMITMENT_R_GENERATOR;
 use crate::note::Note;
 use ff::PrimeField;
@@ -11,8 +11,8 @@ pub struct NetValueCommitment(pallas::Point);
 
 impl NetValueCommitment {
     pub fn new(input_note: &Note, output_note: &Note, blind_r: &pallas::Scalar) -> Self {
-        let base_input = derivate_value_base(input_note.is_normal, &input_note.app);
-        let base_output = derivate_value_base(output_note.is_normal, &output_note.app);
+        let base_input = derivate_value_base(input_note.is_normal, &input_note.application);
+        let base_output = derivate_value_base(output_note.is_normal, &output_note.application);
         NetValueCommitment(
             base_input * pallas::Scalar::from(input_note.value)
                 - base_output * pallas::Scalar::from(output_note.value)
@@ -37,10 +37,10 @@ impl NetValueCommitment {
     }
 }
 
-pub fn derivate_value_base(is_normal: bool, app: &App) -> pallas::Point {
+pub fn derivate_value_base(is_normal: bool, application: &Application) -> pallas::Point {
     let hash = pallas::Point::hash_to_curve("taiga:test");
     let mut bytes: Vec<u8> = vec![is_normal.into()];
-    bytes.extend_from_slice(&app.get_vp().to_repr());
-    bytes.extend_from_slice(&app.vp_data.to_repr());
+    bytes.extend_from_slice(&application.get_vp().to_repr());
+    bytes.extend_from_slice(&application.vp_data.to_repr());
     hash(&bytes)
 }

--- a/taiga_halo2/src/note.rs
+++ b/taiga_halo2/src/note.rs
@@ -2,7 +2,6 @@ use crate::{
     app::App,
     constant::{BASE_BITS_NUM, NOTE_COMMIT_DOMAIN},
     nullifier::Nullifier,
-    user::User,
     utils::extract_p,
 };
 use bitvec::{array::BitArray, order::Lsb0};
@@ -35,8 +34,6 @@ impl Default for NoteCommitment {
 /// A note
 #[derive(Debug, Clone, Default)]
 pub struct Note {
-    /// Owner of the note
-    pub user: User,
     pub app: App,
     pub value: u64,
     /// old nullifier. Nonce which is a deterministically computed, unique nonce
@@ -51,7 +48,6 @@ pub struct Note {
 impl Note {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        user: User,
         app: App,
         value: u64,
         rho: Nullifier,
@@ -60,7 +56,6 @@ impl Note {
         is_normal: bool,
     ) -> Self {
         Self {
-            user,
             app,
             value,
             rho,
@@ -76,13 +71,11 @@ impl Note {
     }
 
     pub fn dummy_from_rho<R: RngCore>(mut rng: R, rho: Nullifier) -> Self {
-        let user = User::dummy(&mut rng);
         let app = App::dummy(&mut rng);
         let value: u64 = rng.gen();
         let rcm = pallas::Scalar::random(&mut rng);
         let psi = pallas::Base::random(&mut rng);
         Self {
-            user,
             app,
             value,
             rho,
@@ -94,7 +87,7 @@ impl Note {
 
     // cm = SinsemillaCommit^rcm(user_address || app_vp || app_data || rho || psi || is_normal || value)
     pub fn commitment(&self) -> NoteCommitment {
-        let user_address = self.user.address();
+        let user_address = self.app.get_user_address();
         let app_vp = self.app.get_vp();
         let ret = NOTE_COMMIT_DOMAIN
             .commit(
@@ -109,7 +102,7 @@ impl Note {
                     .chain(app_vp.to_le_bits().iter().by_vals().take(BASE_BITS_NUM))
                     .chain(
                         self.app
-                            .data
+                            .vp_data
                             .to_le_bits()
                             .iter()
                             .by_vals()
@@ -137,7 +130,7 @@ impl Note {
     }
 
     pub fn get_nf(&self) -> Nullifier {
-        let nk = self.user.get_nk().unwrap();
+        let nk = self.app.get_nk().unwrap();
         let cm = self.commitment();
         Nullifier::derive_native(&nk, &self.rho.inner(), &self.psi, &cm)
     }

--- a/taiga_halo2/src/note.rs
+++ b/taiga_halo2/src/note.rs
@@ -1,5 +1,5 @@
 use crate::{
-    app::App,
+    application::Application,
     constant::{BASE_BITS_NUM, NOTE_COMMIT_DOMAIN},
     nullifier::Nullifier,
     utils::extract_p,
@@ -34,7 +34,7 @@ impl Default for NoteCommitment {
 /// A note
 #[derive(Debug, Clone, Default)]
 pub struct Note {
-    pub app: App,
+    pub application: Application,
     pub value: u64,
     /// old nullifier. Nonce which is a deterministically computed, unique nonce
     pub rho: Nullifier,
@@ -48,7 +48,7 @@ pub struct Note {
 impl Note {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        app: App,
+        application: Application,
         value: u64,
         rho: Nullifier,
         psi: pallas::Base,
@@ -56,7 +56,7 @@ impl Note {
         is_normal: bool,
     ) -> Self {
         Self {
-            app,
+            application,
             value,
             rho,
             psi,
@@ -71,12 +71,12 @@ impl Note {
     }
 
     pub fn dummy_from_rho<R: RngCore>(mut rng: R, rho: Nullifier) -> Self {
-        let app = App::dummy(&mut rng);
+        let application = Application::dummy(&mut rng);
         let value: u64 = rng.gen();
         let rcm = pallas::Scalar::random(&mut rng);
         let psi = pallas::Base::random(&mut rng);
         Self {
-            app,
+            application,
             value,
             rho,
             psi,
@@ -87,8 +87,8 @@ impl Note {
 
     // cm = SinsemillaCommit^rcm(user_address || app_vp || app_data || rho || psi || is_normal || value)
     pub fn commitment(&self) -> NoteCommitment {
-        let user_address = self.app.get_user_address();
-        let app_vp = self.app.get_vp();
+        let user_address = self.application.get_user_address();
+        let app_vp = self.application.get_vp();
         let ret = NOTE_COMMIT_DOMAIN
             .commit(
                 iter::empty()
@@ -101,7 +101,7 @@ impl Note {
                     )
                     .chain(app_vp.to_le_bits().iter().by_vals().take(BASE_BITS_NUM))
                     .chain(
-                        self.app
+                        self.application
                             .vp_data
                             .to_le_bits()
                             .iter()
@@ -130,7 +130,7 @@ impl Note {
     }
 
     pub fn get_nf(&self) -> Nullifier {
-        let nk = self.app.get_nk().unwrap();
+        let nk = self.application.get_nk().unwrap();
         let cm = self.commitment();
         Nullifier::derive_native(&nk, &self.rho.inner(), &self.psi, &cm)
     }

--- a/taiga_halo2/src/note.rs
+++ b/taiga_halo2/src/note.rs
@@ -102,7 +102,7 @@ impl Note {
                     .chain(app_vp.to_le_bits().iter().by_vals().take(BASE_BITS_NUM))
                     .chain(
                         self.application
-                            .vp_data
+                            .get_vp_data()
                             .to_le_bits()
                             .iter()
                             .by_vals()

--- a/taiga_halo2/src/user.rs
+++ b/taiga_halo2/src/user.rs
@@ -36,88 +36,133 @@ impl Default for NullifierDerivingKey {
 /// The user address binded with send vp and received vp.
 #[derive(Debug, Clone)]
 pub struct User {
-    pub send_com: UserSendAddress,
-    pub recv_vp: ValidityPredicateDescription,
+    send_data: UserSendData,
+    recv_data: UserData,
 }
 
 #[derive(Debug, Clone)]
-pub enum UserSendAddress {
+pub enum UserSendData {
     Closed(pallas::Base),
-    Open(NullifierDerivingKey, ValidityPredicateDescription),
+    Open(NullifierDerivingKey, UserData),
+}
+
+#[derive(Debug, Clone)]
+pub enum UserData {
+    General(pallas::Base),
+    Vp(ValidityPredicateDescription),
+}
+
+impl UserData {
+    pub fn from_vp(vp: ValidityPredicateDescription) -> Self {
+        UserData::Vp(vp)
+    }
+
+    pub fn get_data(&self) -> pallas::Base {
+        match self {
+            UserData::General(v) => *v,
+            UserData::Vp(vp) => vp.get_compressed(),
+        }
+    }
 }
 
 impl User {
-    pub fn new(
-        send_vp: ValidityPredicateDescription,
-        recv_vp: ValidityPredicateDescription,
-        nk: NullifierDerivingKey,
-    ) -> Self {
-        let send_com = UserSendAddress::from_open(nk, send_vp);
-        Self { send_com, recv_vp }
+    pub fn new(nk: NullifierDerivingKey, send_data: UserData, recv_data: UserData) -> Self {
+        let send_data = UserSendData::from_open(nk, send_data);
+        Self {
+            send_data,
+            recv_data,
+        }
     }
 
     pub fn dummy(rng: &mut impl RngCore) -> Self {
         let nk = NullifierDerivingKey::rand(rng);
-        let send_vp = ValidityPredicateDescription::dummy(rng);
-        let send_com = UserSendAddress::from_open(nk, send_vp);
+        let send_data = UserData::from_vp(ValidityPredicateDescription::dummy(rng));
+        let send_data = UserSendData::from_open(nk, send_data);
         Self {
-            send_com,
-            recv_vp: ValidityPredicateDescription::dummy(rng),
+            send_data,
+            recv_data: UserData::from_vp(ValidityPredicateDescription::dummy(rng)),
         }
     }
 
     pub fn address(&self) -> pallas::Base {
-        // address = Com_r(send_com || recv_vp_hash), use poseidon hash as Com_r
-        poseidon_hash(self.send_com.get_closed(), self.recv_vp.get_compressed())
+        // address = Com_r(send_com || recv_data_hash), use poseidon hash as Com_r
+        poseidon_hash(self.send_data.get_closed(), self.recv_data.get_data())
     }
 
     pub fn get_nk(&self) -> Option<NullifierDerivingKey> {
-        self.send_com.get_nk()
+        self.send_data.get_nk()
+    }
+
+    pub fn get_send_closed(&self) -> pallas::Base {
+        self.send_data.get_closed()
+    }
+
+    pub fn get_send_data(&self) -> Option<pallas::Base> {
+        self.send_data.get_data()
+    }
+
+    pub fn get_recv_data(&self) -> pallas::Base {
+        self.recv_data.get_data()
     }
 }
 
-impl UserSendAddress {
+impl UserSendData {
     /// Creates an open user send address.
-    pub fn from_open(nk: NullifierDerivingKey, send_vp: ValidityPredicateDescription) -> Self {
-        UserSendAddress::Open(nk, send_vp)
+    pub fn from_open(nk: NullifierDerivingKey, send_data: UserData) -> Self {
+        UserSendData::Open(nk, send_data)
     }
 
     /// Creates a closed user send address.
     pub fn from_closed(x: pallas::Base) -> Self {
-        UserSendAddress::Closed(x)
+        UserSendData::Closed(x)
     }
 
     pub fn get_nk(&self) -> Option<NullifierDerivingKey> {
         match self {
-            UserSendAddress::Closed(_) => None,
-            UserSendAddress::Open(nk, _) => Some(*nk),
+            UserSendData::Closed(_) => None,
+            UserSendData::Open(nk, _) => Some(*nk),
         }
     }
 
     pub fn get_send_vp(&self) -> Option<&ValidityPredicateDescription> {
         match self {
-            UserSendAddress::Closed(_) => None,
-            UserSendAddress::Open(_, send_vp) => Some(send_vp),
+            UserSendData::Open(_, UserData::Vp(vp)) => Some(vp),
+            _ => None,
+        }
+    }
+
+    pub fn get_data(&self) -> Option<pallas::Base> {
+        match self {
+            UserSendData::Closed(_) => None,
+            UserSendData::Open(_, send_data) => Some(send_data.get_data()),
         }
     }
 
     pub fn get_closed(&self) -> pallas::Base {
         match self {
-            UserSendAddress::Closed(v) => *v,
-            UserSendAddress::Open(nk, send_vp) => {
-                // Com_r(send_vp, nk), use poseidon hash as Com_r.
-                poseidon_hash(send_vp.get_compressed(), nk.inner())
+            UserSendData::Closed(v) => *v,
+            UserSendData::Open(nk, send_data) => {
+                // Com_r(send_data, nk), use poseidon hash as Com_r.
+                poseidon_hash(send_data.get_data(), nk.inner())
             }
         }
+    }
+}
+
+impl Default for UserData {
+    fn default() -> UserData {
+        UserData::General(pallas::Base::one())
     }
 }
 
 impl Default for User {
     fn default() -> User {
         let nk = NullifierDerivingKey::default();
-        let send_vp = ValidityPredicateDescription::Compressed(pallas::Base::one());
-        let send_com = UserSendAddress::from_open(nk, send_vp);
-        let recv_vp = ValidityPredicateDescription::Compressed(pallas::Base::one());
-        User { send_com, recv_vp }
+        let send_data = UserSendData::from_open(nk, UserData::default());
+        let recv_data = UserData::default();
+        User {
+            send_data,
+            recv_data,
+        }
     }
 }

--- a/taiga_halo2/src/vp_description.rs
+++ b/taiga_halo2/src/vp_description.rs
@@ -49,3 +49,9 @@ impl ValidityPredicateDescription {
         Self::Compressed(pallas::Base::random(rng))
     }
 }
+
+impl Default for ValidityPredicateDescription {
+    fn default() -> ValidityPredicateDescription {
+        ValidityPredicateDescription::Compressed(pallas::Base::one())
+    }
+}


### PR DESCRIPTION
- Move `User` into `Application`, and the user data won't be derivated in value base
- Use general user_data instead of user vps. Since the `nk` needs to be binded with the send_address/vp/data, I keep the basic structure of `User = Com( Com(send_data, nk), recv_data)` if it makes sense.