### PR TITLE
Include custom_contraints and basic_contraints to sudoku VP

### DIFF
--- a/taiga_halo2/examples/sudoku/app/valid_sudoku/vp.rs
+++ b/taiga_halo2/examples/sudoku/app/valid_sudoku/vp.rs
@@ -1,17 +1,23 @@
-use halo2_proofs::plonk::ConstraintSystem;
-use pasta_curves::pallas;
+use halo2_proofs::{
+    circuit::{Layouter},
+    transcript::Blake2bWrite,
+    plonk::{ self, Circuit, ConstraintSystem, Error, keygen_vk, keygen_pk, create_proof}
+};
+use pasta_curves::{pallas, vesta, Fp};
 
 extern crate taiga_halo2;
 use taiga_halo2::{
     circuit::{
         note_circuit::NoteConfig,
-        vp_circuit::{ValidityPredicateCircuit, ValidityPredicateConfig, ValidityPredicateInfo},
+        vp_circuit::{ValidityPredicateCircuit, ValidityPredicateConfig, ValidityPredicateInfo, VPVerifyingInfo},
     },
-    constant::NUM_NOTE,
+    vp_description::ValidityPredicateDescription,
+    constant::{NUM_NOTE, SETUP_PARAMS_MAP},
     note::Note,
 };
 
-use crate::app::valid_sudoku::circuit::SudokuCircuit;
+use rand::rngs::OsRng;
+use crate::app::valid_sudoku::circuit::{SudokuCircuit, SudokuConfig};
 
 #[derive(Clone, Debug)]
 pub struct SudokuVPConfig {
@@ -36,9 +42,31 @@ pub struct SudokuVP {
     output_notes: [Note; NUM_NOTE],
 }
 
-// impl ValidityPredicateCircuit for SudokuVP {
-//     type VPConfig = SudokuVPConfig;
-// }
+impl ValidityPredicateCircuit for SudokuVP {
+    type VPConfig = SudokuVPConfig;
+}
+
+impl Circuit<pallas::Base> for SudokuVP {
+    type Config = <SudokuCircuit as Circuit<pallas::Base>>::Config;
+    type FloorPlanner = <SudokuCircuit as Circuit<pallas::Base>>::FloorPlanner;
+
+    fn without_witnesses(&self) -> Self {
+        Self::default()
+    }
+
+    fn configure(meta: &mut ConstraintSystem<pallas::Base>) -> Self::Config {
+        SudokuCircuit::configure(meta)
+    }
+
+    #[allow(non_snake_case)]
+    fn synthesize(
+        &self,
+        config: Self::Config,
+        mut layouter: impl Layouter<pallas::Base>,
+    ) -> Result<(), plonk::Error> {
+        self.sudoku.synthesize(config, layouter)
+    }
+}
 
 impl ValidityPredicateInfo for SudokuVP {
     fn get_spend_notes(&self) -> &[Note; NUM_NOTE] {
@@ -54,11 +82,33 @@ impl ValidityPredicateInfo for SudokuVP {
     }
 
     fn get_verifying_info(&self) -> taiga_halo2::circuit::vp_circuit::VPVerifyingInfo {
-        todo!()
+        let mut rng = OsRng;
+        let params = SETUP_PARAMS_MAP.get(&12).unwrap();
+        let vk = keygen_vk(params, self).expect("keygen_vk should not fail");
+        let pk = keygen_pk(params, vk.clone(), self).expect("keygen_pk should not fail");
+        let instance = self.get_instances();
+        let mut transcript = Blake2bWrite::<_, vesta::Affine, _>::init(vec![]);
+        create_proof(
+            params,
+            &pk,
+            &[self.clone()],
+            &[&[&instance]],
+            &mut rng,
+            &mut transcript,
+        )
+        .unwrap();
+        let proof = transcript.finalize();
+        VPVerifyingInfo {
+            vk,
+            proof,
+            instance,
+        }    
     }
 
     fn get_vp_description(&self) -> taiga_halo2::vp_description::ValidityPredicateDescription {
-        todo!()
+        let params = SETUP_PARAMS_MAP.get(&12).unwrap();
+        let vk = keygen_vk(params, self).expect("keygen_vk should not fail");
+        ValidityPredicateDescription::from_vk(vk)
     }
 }
 
@@ -81,7 +131,6 @@ mod tests {
     use std::time::Instant;
 
     use taiga_halo2::{
-        application::Application,
         circuit::gadgets::{
             assign_free_advice, assign_free_instance, AddChip, AddConfig, AddInstructions, MulChip,
             MulConfig, MulInstructions, SubChip, SubConfig, SubInstructions,
@@ -121,22 +170,21 @@ mod tests {
                 [3, 2, 5, 1, 9, 7, 8, 4, 6],
             ],
         };
-
-        let mut vp = SudokuVP::new(sudoku.clone(), input_notes, output_notes);
-
         let vk = VerifyingKey::build(&sudoku, K);
+
+        let mut vp = SudokuVP::new(sudoku, input_notes, output_notes);
+
 
         let vp_desc = ValidityPredicateDescription::from_vk(vk.vk);
 
         let vp_data = pallas::Base::zero(); // TODO: What else can this be?
 
         let user = User::dummy(&mut rng);
-        let application = Application::new(vp_desc, vp_data, user);
 
         let value: u64 = 1; // TODO: What is the correct value here (if any)?
         let rcm = pallas::Scalar::random(&mut rng);
         let psi = pallas::Base::random(&mut rng);
         let rho = Nullifier::new(pallas::Base::random(&mut rng));
-        Note::new(application, value, rho, psi, rcm, true);
+        Note::new(vp_desc, value, rho, psi, rcm, true, vp_data, user, vec!());
     }
 }

--- a/taiga_halo2/examples/sudoku/app/valid_sudoku/vp.rs
+++ b/taiga_halo2/examples/sudoku/app/valid_sudoku/vp.rs
@@ -1,7 +1,7 @@
 use halo2_proofs::{
-    circuit::{Layouter},
+    circuit::Layouter,
+    plonk::{self, create_proof, keygen_pk, keygen_vk, Circuit, ConstraintSystem, Error},
     transcript::Blake2bWrite,
-    plonk::{ self, Circuit, ConstraintSystem, Error, keygen_vk, keygen_pk, create_proof}
 };
 use pasta_curves::{pallas, vesta, Fp};
 
@@ -9,15 +9,18 @@ extern crate taiga_halo2;
 use taiga_halo2::{
     circuit::{
         note_circuit::NoteConfig,
-        vp_circuit::{ValidityPredicateCircuit, ValidityPredicateConfig, ValidityPredicateInfo, VPVerifyingInfo},
+        vp_circuit::{
+            VPVerifyingInfo, ValidityPredicateCircuit, ValidityPredicateConfig,
+            ValidityPredicateInfo,
+        },
     },
-    vp_description::ValidityPredicateDescription,
     constant::{NUM_NOTE, SETUP_PARAMS_MAP},
     note::Note,
+    vp_description::ValidityPredicateDescription,
 };
 
-use rand::rngs::OsRng;
 use crate::app::valid_sudoku::circuit::{SudokuCircuit, SudokuConfig};
+use rand::rngs::OsRng;
 
 #[derive(Clone, Debug)]
 pub struct SudokuVPConfig {
@@ -81,7 +84,7 @@ impl ValidityPredicateInfo for SudokuVP {
         self.get_note_instances()
     }
 
-    fn get_verifying_info(&self) -> taiga_halo2::circuit::vp_circuit::VPVerifyingInfo {
+    fn get_verifying_info(&self) -> VPVerifyingInfo {
         let mut rng = OsRng;
         let params = SETUP_PARAMS_MAP.get(&12).unwrap();
         let vk = keygen_vk(params, self).expect("keygen_vk should not fail");
@@ -102,10 +105,10 @@ impl ValidityPredicateInfo for SudokuVP {
             vk,
             proof,
             instance,
-        }    
+        }
     }
 
-    fn get_vp_description(&self) -> taiga_halo2::vp_description::ValidityPredicateDescription {
+    fn get_vp_description(&self) -> ValidityPredicateDescription {
         let params = SETUP_PARAMS_MAP.get(&12).unwrap();
         let vk = keygen_vk(params, self).expect("keygen_vk should not fail");
         ValidityPredicateDescription::from_vk(vk)
@@ -174,7 +177,6 @@ mod tests {
 
         let mut vp = SudokuVP::new(sudoku, input_notes, output_notes);
 
-
         let vp_desc = ValidityPredicateDescription::from_vk(vk.vk);
 
         let vp_data = pallas::Base::zero(); // TODO: What else can this be?
@@ -185,6 +187,6 @@ mod tests {
         let rcm = pallas::Scalar::random(&mut rng);
         let psi = pallas::Base::random(&mut rng);
         let rho = Nullifier::new(pallas::Base::random(&mut rng));
-        Note::new(vp_desc, value, rho, psi, rcm, true, vp_data, user, vec!());
+        Note::new(vp_desc, value, rho, psi, rcm, true, vp_data, user, vec![]);
     }
 }

--- a/taiga_halo2/examples/sudoku/app/valid_sudoku/vp.rs
+++ b/taiga_halo2/examples/sudoku/app/valid_sudoku/vp.rs
@@ -1,5 +1,5 @@
 use halo2_proofs::{
-    circuit::Layouter,
+    circuit::{floor_planner, Layouter},
     plonk::{self, create_proof, keygen_pk, keygen_vk, Circuit, ConstraintSystem, Error},
     transcript::Blake2bWrite,
 };
@@ -8,6 +8,7 @@ use pasta_curves::{pallas, vesta, Fp};
 extern crate taiga_halo2;
 use taiga_halo2::{
     circuit::{
+        integrity::{OutputNoteVar, SpendNoteVar},
         note_circuit::NoteConfig,
         vp_circuit::{
             VPVerifyingInfo, ValidityPredicateCircuit, ValidityPredicateConfig,
@@ -16,6 +17,7 @@ use taiga_halo2::{
     },
     constant::{NUM_NOTE, SETUP_PARAMS_MAP},
     note::Note,
+    vp_circuit_impl,
     vp_description::ValidityPredicateDescription,
 };
 
@@ -25,6 +27,7 @@ use rand::rngs::OsRng;
 #[derive(Clone, Debug)]
 pub struct SudokuVPConfig {
     note_config: NoteConfig,
+    sudoku_config: SudokuConfig,
 }
 
 impl ValidityPredicateConfig for SudokuVPConfig {
@@ -34,7 +37,8 @@ impl ValidityPredicateConfig for SudokuVPConfig {
 
     fn configure(meta: &mut ConstraintSystem<pallas::Base>) -> Self {
         let note_config = Self::configure_note(meta);
-        Self { note_config }
+        let sudoku_config = SudokuCircuit::configure(meta);
+        Self { note_config, sudoku_config }
     }
 }
 
@@ -47,27 +51,15 @@ pub struct SudokuVP {
 
 impl ValidityPredicateCircuit for SudokuVP {
     type VPConfig = SudokuVPConfig;
-}
 
-impl Circuit<pallas::Base> for SudokuVP {
-    type Config = <SudokuCircuit as Circuit<pallas::Base>>::Config;
-    type FloorPlanner = <SudokuCircuit as Circuit<pallas::Base>>::FloorPlanner;
-
-    fn without_witnesses(&self) -> Self {
-        Self::default()
-    }
-
-    fn configure(meta: &mut ConstraintSystem<pallas::Base>) -> Self::Config {
-        SudokuCircuit::configure(meta)
-    }
-
-    #[allow(non_snake_case)]
-    fn synthesize(
+    fn custom_constraints(
         &self,
-        config: Self::Config,
+        config: Self::VPConfig,
         mut layouter: impl Layouter<pallas::Base>,
+        _spend_note_variables: &[SpendNoteVar],
+        _output_note_variables: &[OutputNoteVar],
     ) -> Result<(), plonk::Error> {
-        self.sudoku.synthesize(config, layouter)
+        self.sudoku.synthesize(config.sudoku_config, layouter)
     }
 }
 
@@ -128,6 +120,8 @@ impl SudokuVP {
         }
     }
 }
+
+vp_circuit_impl!(SudokuVP);
 
 #[cfg(test)]
 mod tests {

--- a/taiga_halo2/examples/sudoku/app/valid_sudoku/vp.rs
+++ b/taiga_halo2/examples/sudoku/app/valid_sudoku/vp.rs
@@ -38,7 +38,10 @@ impl ValidityPredicateConfig for SudokuVPConfig {
     fn configure(meta: &mut ConstraintSystem<pallas::Base>) -> Self {
         let note_config = Self::configure_note(meta);
         let sudoku_config = SudokuCircuit::configure(meta);
-        Self { note_config, sudoku_config }
+        Self {
+            note_config,
+            sudoku_config,
+        }
     }
 }
 


### PR DESCRIPTION
Remove duplication of circuit trait and call the sudoku circuit `synthesise` function to the sudoku vp `custom_contraints`, modify the config of the VP and call the macro `vp_circuit_impl` to embed the VP constraints into the circuit