### PR TITLE
remove the note_data

### DIFF
--- a/taiga_halo2/examples/simple_sudoku/circuit.rs
+++ b/taiga_halo2/examples/simple_sudoku/circuit.rs
@@ -383,15 +383,11 @@ impl plonk::Circuit<pallas::Base> for SudokuCircuit {
 
 #[cfg(test)]
 mod tests {
+    use crate::circuit::SudokuCircuit;
     use halo2_proofs::{arithmetic::FieldExt, dev::MockProver};
     use rand::rngs::OsRng;
 
-    use crate::valid_sudoku::circuit::SudokuCircuit;
-
-    use halo2_proofs::{
-        plonk::{self, ProvingKey, VerifyingKey},
-        poly::commitment::Params,
-    };
+    use halo2_proofs::{plonk, poly::commitment::Params};
     use pasta_curves::{pallas, vesta};
     use std::time::Instant;
     use taiga_halo2::proof::Proof;
@@ -441,31 +437,31 @@ mod tests {
         );
         let pub_instance: [pallas::Base; 108] = pub_instance_vec.try_into().unwrap();
 
-        // ------- PLOTTING SECTION --------
-        use plotters::prelude::*;
-        let root = BitMapBackend::new("layout.png", (1024, 768)).into_drawing_area();
-        root.fill(&WHITE).unwrap();
-        let root = root
-            .titled("Example Circuit Layout", ("sans-serif", 60))
-            .unwrap();
+        // // ------- PLOTTING SECTION --------
+        // use plotters::prelude::*;
+        // let root = BitMapBackend::new("layout.png", (1024, 768)).into_drawing_area();
+        // root.fill(&WHITE).unwrap();
+        // let root = root
+        //     .titled("Example Circuit Layout", ("sans-serif", 60))
+        //     .unwrap();
 
-        halo2_proofs::dev::CircuitLayout::default()
-            // You can optionally render only a section of the circuit.
-            // .view_width(0..7)
-            // .view_height(0..60)
-            // You can hide labels, which can be useful with smaller areas.
-            .show_labels(false)
-            // Render the circuit onto your area!
-            // The first argument is the size parameter for the circuit.
-            .render(K, &circuit, &root)
-            .unwrap();
+        // halo2_proofs::dev::CircuitLayout::default()
+        //     // You can optionally render only a section of the circuit.
+        //     // .view_width(0..7)
+        //     // .view_height(0..60)
+        //     // You can hide labels, which can be useful with smaller areas.
+        //     .show_labels(false)
+        //     // Render the circuit onto your area!
+        //     // The first argument is the size parameter for the circuit.
+        //     .render(K, &circuit, &root)
+        //     .unwrap();
 
-        let dot_string = halo2_proofs::dev::circuit_dot_graph(&circuit);
+        // let dot_string = halo2_proofs::dev::circuit_dot_graph(&circuit);
 
-        // Now you can either handle it in Rust, or just
-        // print it out to use with command-line tools.
-        print!("{}", dot_string);
-        // ---- END OF PLOTTING SECTION --------
+        // // Now you can either handle it in Rust, or just
+        // // print it out to use with command-line tools.
+        // print!("{}", dot_string);
+        // // ---- END OF PLOTTING SECTION --------
 
         println!("Success!");
         let time = Instant::now();
@@ -494,7 +490,7 @@ mod tests {
 
     #[test]
     fn test_synthesize() {
-        use crate::valid_sudoku::circuit::SudokuCircuit;
+        use crate::circuit::SudokuCircuit;
 
         let sudoku = [
             [5, 8, 1, 6, 7, 2, 4, 3, 9],
@@ -513,6 +509,6 @@ mod tests {
         let circuit = SudokuCircuit { sudoku };
         let params: Params<vesta::Affine> = Params::new(K);
 
-        let vk = plonk::keygen_vk(&params, &circuit).unwrap(); // this would fail on this specific puzzle with the old implementation of synthesize
+        let _vk = plonk::keygen_vk(&params, &circuit).unwrap(); // this would fail on this specific puzzle with the old implementation of synthesize
     }
 }

--- a/taiga_halo2/examples/simple_sudoku/vp.rs
+++ b/taiga_halo2/examples/simple_sudoku/vp.rs
@@ -118,15 +118,7 @@ vp_circuit_impl!(SudokuVP);
 
 #[cfg(test)]
 mod tests {
-    use std::time::Instant;
-
     use taiga_halo2::{
-        circuit::gadgets::{
-            add::{AddChip, AddConfig, AddInstructions},
-            assign_free_advice, assign_free_instance,
-            mul::{MulChip, MulConfig, MulInstructions},
-            sub::{SubChip, SubConfig, SubInstructions},
-        },
         constant::NUM_NOTE,
         note::Note,
         nullifier::{Nullifier, NullifierKeyCom},
@@ -137,12 +129,9 @@ mod tests {
     use pasta_curves::pallas;
     use rand::rngs::OsRng;
 
-    use halo2_proofs::{
-        plonk::{self, ProvingKey, VerifyingKey},
-        poly::commitment::Params,
-    };
+    use halo2_proofs::{plonk, poly::commitment::Params};
 
-    use crate::valid_sudoku::{circuit::SudokuCircuit, vp::SudokuVP};
+    use crate::{circuit::SudokuCircuit, vp::SudokuVP};
 
     #[test]
     fn test_vp() {
@@ -190,7 +179,6 @@ mod tests {
             psi,
             rcm,
             true,
-            vec![],
         );
     }
 }

--- a/taiga_halo2/src/circuit/note_circuit.rs
+++ b/taiga_halo2/src/circuit/note_circuit.rs
@@ -835,7 +835,6 @@ fn test_halo2_note_commitment_circuit() {
                 self.psi,
                 self.rcm,
                 self.is_merkle_checked,
-                vec![0u8; 32],
             );
             // Construct a Sinsemilla chip
             let sinsemilla_chip =

--- a/taiga_halo2/src/note.rs
+++ b/taiga_halo2/src/note.rs
@@ -57,8 +57,6 @@ pub struct Note {
     pub rcm: pallas::Scalar,
     /// If the is_merkle_checked flag is true, the merkle path authorization(membership) of the spent note will be checked in ActionProof.
     pub is_merkle_checked: bool,
-    /// note data bytes
-    pub note_data: Vec<u8>,
 }
 
 /// The parameters in the NoteType are used to derive note value base.
@@ -98,7 +96,6 @@ impl Note {
         psi: pallas::Base,
         rcm: pallas::Scalar,
         is_merkle_checked: bool,
-        note_data: Vec<u8>,
     ) -> Self {
         let value_base = NoteType::new(app_vk, app_data);
         Self {
@@ -110,7 +107,6 @@ impl Note {
             psi,
             rcm,
             is_merkle_checked,
-            note_data,
         }
     }
 
@@ -128,7 +124,6 @@ impl Note {
         let nk_com = NullifierKeyCom::rand(&mut rng);
         let rcm = pallas::Scalar::random(&mut rng);
         let psi = pallas::Base::random(&mut rng);
-        let note_data = vec![0u8; 32];
         Self {
             value_base,
             app_data_dynamic,
@@ -138,7 +133,6 @@ impl Note {
             psi,
             rcm,
             is_merkle_checked: true,
-            note_data,
         }
     }
 

--- a/taiga_halo2/src/transaction.rs
+++ b/taiga_halo2/src/transaction.rs
@@ -418,7 +418,6 @@ fn test_transaction_creation() {
             psi,
             rcm,
             is_merkle_checked,
-            vec![0u8; 32],
         )
     };
     let output_note_1 = {
@@ -442,7 +441,6 @@ fn test_transaction_creation() {
             psi,
             rcm,
             is_merkle_checked,
-            vec![0u8; 32],
         )
     };
     let spend_note_2 = spend_note_1.clone();


### PR DESCRIPTION
> To keep notes lightweight, we aim to encode any arbitrary data inside app_data and app_data_dynamic and the encoding mechanisms are application dependent, so we don't need note_data.