### PR TITLE
some renames and vp circuit trait refinement

### DIFF
--- a/taiga_halo2/examples/simple_sudoku/vp.rs
+++ b/taiga_halo2/examples/simple_sudoku/vp.rs
@@ -11,7 +11,7 @@ use taiga_halo2::{
         note_circuit::NoteConfig,
         vp_circuit::{
             VPVerifyingInfo, ValidityPredicateCircuit, ValidityPredicateConfig,
-            ValidityPredicateInfo,
+            ValidityPredicateInfo, ValidityPredicateVerifyingInfo,
         },
     },
     constant::{NUM_NOTE, SETUP_PARAMS_MAP},
@@ -78,26 +78,6 @@ impl ValidityPredicateInfo for SudokuVP {
     fn get_instances(&self) -> Vec<pallas::Base> {
         self.get_note_instances()
     }
-
-    fn get_verifying_info(&self) -> VPVerifyingInfo {
-        let mut rng = OsRng;
-        let params = SETUP_PARAMS_MAP.get(&12).unwrap();
-        let vk = keygen_vk(params, self).expect("keygen_vk should not fail");
-        let pk = keygen_pk(params, vk.clone(), self).expect("keygen_pk should not fail");
-        let instance = self.get_instances();
-        let proof = Proof::create(&pk, params, self.clone(), &[&instance], &mut rng).unwrap();
-        VPVerifyingInfo {
-            vk,
-            proof,
-            instance,
-        }
-    }
-
-    fn get_vp_description(&self) -> ValidityPredicateVerifyingKey {
-        let params = SETUP_PARAMS_MAP.get(&12).unwrap();
-        let vk = keygen_vk(params, self).expect("keygen_vk should not fail");
-        ValidityPredicateVerifyingKey::from_vk(vk)
-    }
 }
 
 impl SudokuVP {
@@ -159,7 +139,7 @@ mod tests {
 
         let mut _vp = SudokuVP::new(sudoku, input_notes, output_notes);
 
-        let vp_desc = ValidityPredicateVerifyingKey::from_vk(vk);
+        let vp_vk = ValidityPredicateVerifyingKey::from_vk(vk);
 
         let app_data_static = pallas::Base::zero();
         let app_data_dynamic = pallas::Base::zero();
@@ -170,7 +150,7 @@ mod tests {
         let psi = pallas::Base::random(&mut rng);
         let rho = Nullifier::new(pallas::Base::random(&mut rng));
         Note::new(
-            vp_desc,
+            vp_vk,
             app_data_static,
             app_data_dynamic,
             value,

--- a/taiga_halo2/examples/simple_sudoku/vp.rs
+++ b/taiga_halo2/examples/simple_sudoku/vp.rs
@@ -161,7 +161,7 @@ mod tests {
 
         let vp_desc = ValidityPredicateVerifyingKey::from_vk(vk);
 
-        let app_data = pallas::Base::zero();
+        let app_data_static = pallas::Base::zero();
         let app_data_dynamic = pallas::Base::zero();
 
         let value: u64 = 0;
@@ -171,7 +171,7 @@ mod tests {
         let rho = Nullifier::new(pallas::Base::random(&mut rng));
         Note::new(
             vp_desc,
-            app_data,
+            app_data_static,
             app_data_dynamic,
             value,
             nk_com,

--- a/taiga_halo2/examples/taiga_sudoku/app_vp.rs
+++ b/taiga_halo2/examples/taiga_sudoku/app_vp.rs
@@ -23,7 +23,7 @@ use taiga_halo2::{
         note_circuit::NoteConfig,
         vp_circuit::{
             VPVerifyingInfo, ValidityPredicateCircuit, ValidityPredicateConfig,
-            ValidityPredicateInfo,
+            ValidityPredicateInfo, ValidityPredicateVerifyingInfo,
         },
     },
     constant::{NUM_NOTE, SETUP_PARAMS_MAP},
@@ -474,26 +474,6 @@ impl ValidityPredicateInfo for SudokuAppValidityPredicateCircuit {
         instances.push(self.is_spend_note);
 
         instances
-    }
-
-    fn get_verifying_info(&self) -> VPVerifyingInfo {
-        let mut rng = OsRng;
-        let params = SETUP_PARAMS_MAP.get(&12).unwrap();
-        let vk = keygen_vk(params, self).expect("keygen_vk should not fail");
-        let pk = keygen_pk(params, vk.clone(), self).expect("keygen_pk should not fail");
-        let instance = self.get_instances();
-        let proof = Proof::create(&pk, params, self.clone(), &[&instance], &mut rng).unwrap();
-        VPVerifyingInfo {
-            vk,
-            proof,
-            instance,
-        }
-    }
-
-    fn get_vp_description(&self) -> ValidityPredicateVerifyingKey {
-        let params = SETUP_PARAMS_MAP.get(&12).unwrap();
-        let vk = keygen_vk(params, self).expect("keygen_vk should not fail");
-        ValidityPredicateVerifyingKey::from_vk(vk)
     }
 }
 

--- a/taiga_halo2/examples/taiga_sudoku/app_vp.rs
+++ b/taiga_halo2/examples/taiga_sudoku/app_vp.rs
@@ -45,7 +45,7 @@ pub struct SudokuState {
 
 impl SudokuState {
     pub fn encode(&self) -> pallas::Base {
-        // TODO: add the rho of note to make the app_data unique.
+        // TODO: add the rho of note to make the app_data_static unique.
 
         let sudoku = self.state.concat();
         let s1 = &sudoku[..sudoku.len() / 2]; // s1 contains 40 elements
@@ -190,7 +190,7 @@ impl SudokuAppValidityPredicateCircuit {
         let encoded_init_state = SudokuState::default().encode();
         let previous_state = SudokuState::default();
         let current_state = SudokuState::default();
-        output_notes[0].note_type.app_data =
+        output_notes[0].note_type.app_data_static =
             poseidon_hash(encoded_init_state, current_state.encode());
         output_notes[0].value = 1u64;
         Self {
@@ -320,7 +320,7 @@ impl SudokuAppValidityPredicateCircuit {
         init_state: &AssignedCell<pallas::Base, pallas::Base>,
         spend_note_pre_state: &AssignedCell<pallas::Base, pallas::Base>,
         output_note_cur_state: &AssignedCell<pallas::Base, pallas::Base>,
-        spend_note_app_data_encode: &AssignedCell<pallas::Base, pallas::Base>,
+        spend_note_app_data_static_encode: &AssignedCell<pallas::Base, pallas::Base>,
         spend_note: &SpendNoteVar,
         output_note: &OutputNoteVar,
     ) -> Result<(), Error> {
@@ -330,8 +330,8 @@ impl SudokuAppValidityPredicateCircuit {
                 config.assign_region(
                     is_spend_note,
                     init_state,
-                    &spend_note.app_data,
-                    spend_note_app_data_encode,
+                    &spend_note.app_data_static,
+                    spend_note_app_data_static_encode,
                     &spend_note.app_vk,
                     &output_note.app_vk,
                     spend_note_pre_state,
@@ -561,13 +561,13 @@ impl ValidityPredicateCircuit for SudokuAppValidityPredicateCircuit {
             Value::known(self.current_state.encode()),
         )?;
 
-        // app_data = poseidon_hash(encoded_init_state || encoded_state)
+        // app_data_static = poseidon_hash(encoded_init_state || encoded_state)
         let encoded_init_state = assign_free_advice(
             layouter.namespace(|| "witness encoded_init_state"),
             config.advices[0],
             Value::known(self.encoded_init_state),
         )?;
-        let spend_note_app_data_encode = {
+        let spend_note_app_data_static_encode = {
             let poseidon_config = config.get_note_config().poseidon_config;
             let poseidon_chip = PoseidonChip::construct(poseidon_config);
             let poseidon_hasher =
@@ -577,11 +577,11 @@ impl ValidityPredicateCircuit for SudokuAppValidityPredicateCircuit {
                 )?;
             let poseidon_message = [encoded_init_state.clone(), encoded_previous_state.clone()];
             poseidon_hasher.hash(
-                layouter.namespace(|| "get spend note app_data encoding"),
+                layouter.namespace(|| "get spend note app_data_static encoding"),
                 poseidon_message,
             )?
         };
-        let output_note_app_data_encode = {
+        let output_note_app_data_static_encode = {
             let poseidon_config = config.get_note_config().poseidon_config;
             let poseidon_chip = PoseidonChip::construct(poseidon_config);
             let poseidon_hasher =
@@ -591,17 +591,17 @@ impl ValidityPredicateCircuit for SudokuAppValidityPredicateCircuit {
                 )?;
             let poseidon_message = [encoded_init_state.clone(), encoded_current_state.clone()];
             poseidon_hasher.hash(
-                layouter.namespace(|| "get output note app_data encoding"),
+                layouter.namespace(|| "get output note app_data_static encoding"),
                 poseidon_message,
             )?
         };
 
         layouter.assign_region(
-            || "check output note app_data encoding",
+            || "check output note app_data_static encoding",
             |mut region| {
                 region.constrain_equal(
-                    output_note_app_data_encode.cell(),
-                    output_note_variables[0].app_data.cell(),
+                    output_note_app_data_static_encode.cell(),
+                    output_note_variables[0].app_data_static.cell(),
                 )
             },
         )?;
@@ -620,7 +620,7 @@ impl ValidityPredicateCircuit for SudokuAppValidityPredicateCircuit {
             &encoded_init_state,
             &encoded_previous_state,
             &encoded_current_state,
-            &spend_note_app_data_encode,
+            &spend_note_app_data_static_encode,
             &spend_note_variables[0],
             &output_note_variables[0],
         )?;
@@ -709,10 +709,10 @@ fn test_halo2_sudoku_app_vp_circuit_update() {
                 [6, 0, 7, 4, 3, 5, 1, 9, 8],
             ],
         };
-        spend_notes[0].note_type.app_data =
+        spend_notes[0].note_type.app_data_static =
             poseidon_hash(encoded_init_state, previous_state.encode());
         spend_notes[0].value = 1u64;
-        output_notes[0].note_type.app_data =
+        output_notes[0].note_type.app_data_static =
             poseidon_hash(encoded_init_state, current_state.encode());
         output_notes[0].value = 1u64;
         output_notes[0].note_type.app_vk = spend_notes[0].note_type.app_vk.clone();
@@ -780,10 +780,10 @@ pub fn halo2_sudoku_app_vp_circuit_final() {
                 [6, 2, 7, 4, 3, 5, 1, 9, 8],
             ],
         };
-        spend_notes[0].note_type.app_data =
+        spend_notes[0].note_type.app_data_static =
             poseidon_hash(encoded_init_state, previous_state.encode());
         spend_notes[0].value = 1u64;
-        output_notes[0].note_type.app_data =
+        output_notes[0].note_type.app_data_static =
             poseidon_hash(encoded_init_state, current_state.encode());
         output_notes[0].value = 0u64;
         output_notes[0].note_type.app_vk = spend_notes[0].note_type.app_vk.clone();

--- a/taiga_halo2/examples/taiga_sudoku/dealer_intent_app_vp.rs
+++ b/taiga_halo2/examples/taiga_sudoku/dealer_intent_app_vp.rs
@@ -92,7 +92,8 @@ impl DealerIntentValidityPredicateCircuit {
         let is_spend_note = pallas::Base::zero();
         let encoded_puzzle = pallas::Base::random(&mut rng);
         let sudoku_app_vk = ValidityPredicateVerifyingKey::dummy(&mut rng).get_compressed();
-        output_notes[0].note_type.app_data = Self::compute_app_data(encoded_puzzle, sudoku_app_vk);
+        output_notes[0].note_type.app_data_static =
+            Self::compute_app_data_static(encoded_puzzle, sudoku_app_vk);
         let encoded_solution = pallas::Base::random(&mut rng);
         Self {
             spend_notes,
@@ -104,7 +105,7 @@ impl DealerIntentValidityPredicateCircuit {
         }
     }
 
-    pub fn compute_app_data(
+    pub fn compute_app_data_static(
         encoded_puzzle: pallas::Base,
         sudoku_app_vk: pallas::Base,
     ) -> pallas::Base {
@@ -120,13 +121,13 @@ impl DealerIntentValidityPredicateCircuit {
         sudoku_app_vk_in_dealer_intent_note: &AssignedCell<pallas::Base, pallas::Base>,
         puzzle_note: &OutputNoteVar,
     ) -> Result<(), Error> {
-        // puzzle_note_app_data = poseidon_hash(encoded_puzzle || encoded_solution)
+        // puzzle_note_app_data_static = poseidon_hash(encoded_puzzle || encoded_solution)
         let encoded_solution = assign_free_advice(
             layouter.namespace(|| "witness encoded_solution"),
             config.advices[0],
             Value::known(self.encoded_solution),
         )?;
-        let encoded_puzzle_note_app_data = {
+        let encoded_puzzle_note_app_data_static = {
             let poseidon_config = config.get_note_config().poseidon_config;
             let poseidon_chip = PoseidonChip::construct(poseidon_config);
             let poseidon_hasher =
@@ -136,7 +137,7 @@ impl DealerIntentValidityPredicateCircuit {
                 )?;
             let poseidon_message = [encoded_puzzle.clone(), encoded_solution];
             poseidon_hasher.hash(
-                layouter.namespace(|| "check app_data encoding"),
+                layouter.namespace(|| "check app_data_static encoding"),
                 poseidon_message,
             )?
         };
@@ -149,8 +150,8 @@ impl DealerIntentValidityPredicateCircuit {
                     &puzzle_note.value,
                     &puzzle_note.app_vk,
                     sudoku_app_vk_in_dealer_intent_note,
-                    &puzzle_note.app_data,
-                    &encoded_puzzle_note_app_data,
+                    &puzzle_note.app_data_static,
+                    &encoded_puzzle_note_app_data_static,
                     0,
                     &mut region,
                 )
@@ -216,21 +217,21 @@ impl ValidityPredicateCircuit for DealerIntentValidityPredicateCircuit {
         // publicize is_spend_note and check it outside of circuit.
         layouter.constrain_instance(is_spend_note.cell(), config.instances, 2 * NUM_NOTE)?;
 
-        // search target note and output the app_data
-        let app_data = layouter.assign_region(
-            || "get target app_data",
+        // search target note and output the app_data_static
+        let app_data_static = layouter.assign_region(
+            || "get target app_data_static",
             |mut region| {
                 config.get_target_variable_config.assign_region(
                     &is_spend_note,
-                    &spend_note_variables[0].app_data,
-                    &output_note_variables[0].app_data,
+                    &spend_note_variables[0].app_data_static,
+                    &output_note_variables[0].app_data_static,
                     0,
                     &mut region,
                 )
             },
         )?;
 
-        // app_data = poseidon_hash(encoded_puzzle || sudoku_app_vk)
+        // app_data_static = poseidon_hash(encoded_puzzle || sudoku_app_vk)
         let encoded_puzzle = assign_free_advice(
             layouter.namespace(|| "witness encoded_puzzle"),
             config.advices[0],
@@ -241,7 +242,7 @@ impl ValidityPredicateCircuit for DealerIntentValidityPredicateCircuit {
             config.advices[0],
             Value::known(self.sudoku_app_vk),
         )?;
-        let app_data_encode = {
+        let app_data_static_encode = {
             let poseidon_config = config.get_note_config().poseidon_config;
             let poseidon_chip = PoseidonChip::construct(poseidon_config);
             let poseidon_hasher =
@@ -251,14 +252,16 @@ impl ValidityPredicateCircuit for DealerIntentValidityPredicateCircuit {
                 )?;
             let poseidon_message = [encoded_puzzle.clone(), sudoku_app_vk.clone()];
             poseidon_hasher.hash(
-                layouter.namespace(|| "check app_data encoding"),
+                layouter.namespace(|| "check app_data_static encoding"),
                 poseidon_message,
             )?
         };
 
         layouter.assign_region(
-            || "check app_data encoding",
-            |mut region| region.constrain_equal(app_data_encode.cell(), app_data.cell()),
+            || "check app_data_static encoding",
+            |mut region| {
+                region.constrain_equal(app_data_static_encode.cell(), app_data_static.cell())
+            },
         )?;
 
         // if it is an output note, do nothing
@@ -283,8 +286,8 @@ pub struct DealerIntentCheckConfig {
     puzzle_note_value: Column<Advice>,
     sudoku_app_vk: Column<Advice>,
     sudoku_app_vk_in_dealer_intent_note: Column<Advice>,
-    puzzle_note_app_data: Column<Advice>,
-    encoded_puzzle_note_app_data: Column<Advice>,
+    puzzle_note_app_data_static: Column<Advice>,
+    encoded_puzzle_note_app_data_static: Column<Advice>,
 }
 
 impl DealerIntentCheckConfig {
@@ -295,15 +298,15 @@ impl DealerIntentCheckConfig {
         puzzle_note_value: Column<Advice>,
         sudoku_app_vk: Column<Advice>,
         sudoku_app_vk_in_dealer_intent_note: Column<Advice>,
-        puzzle_note_app_data: Column<Advice>,
-        encoded_puzzle_note_app_data: Column<Advice>,
+        puzzle_note_app_data_static: Column<Advice>,
+        encoded_puzzle_note_app_data_static: Column<Advice>,
     ) -> Self {
         meta.enable_equality(is_spend_note);
         meta.enable_equality(puzzle_note_value);
         meta.enable_equality(sudoku_app_vk);
         meta.enable_equality(sudoku_app_vk_in_dealer_intent_note);
-        meta.enable_equality(puzzle_note_app_data);
-        meta.enable_equality(encoded_puzzle_note_app_data);
+        meta.enable_equality(puzzle_note_app_data_static);
+        meta.enable_equality(encoded_puzzle_note_app_data_static);
 
         let config = Self {
             q_dealer_intent_check: meta.selector(),
@@ -311,8 +314,8 @@ impl DealerIntentCheckConfig {
             puzzle_note_value,
             sudoku_app_vk,
             sudoku_app_vk_in_dealer_intent_note,
-            puzzle_note_app_data,
-            encoded_puzzle_note_app_data,
+            puzzle_note_app_data_static,
+            encoded_puzzle_note_app_data_static,
         };
 
         config.create_gate(meta);
@@ -328,10 +331,10 @@ impl DealerIntentCheckConfig {
             let sudoku_app_vk = meta.query_advice(self.sudoku_app_vk, Rotation::cur());
             let sudoku_app_vk_in_dealer_intent_note =
                 meta.query_advice(self.sudoku_app_vk_in_dealer_intent_note, Rotation::cur());
-            let puzzle_note_app_data =
-                meta.query_advice(self.puzzle_note_app_data, Rotation::cur());
-            let encoded_puzzle_note_app_data =
-                meta.query_advice(self.encoded_puzzle_note_app_data, Rotation::cur());
+            let puzzle_note_app_data_static =
+                meta.query_advice(self.puzzle_note_app_data_static, Rotation::cur());
+            let encoded_puzzle_note_app_data_static =
+                meta.query_advice(self.encoded_puzzle_note_app_data_static, Rotation::cur());
 
             let bool_check_is_spend = bool_check(is_spend_note.clone());
 
@@ -349,8 +352,9 @@ impl DealerIntentCheckConfig {
                             * (sudoku_app_vk - sudoku_app_vk_in_dealer_intent_note),
                     ),
                     (
-                        "check puzzle note app_data encoding",
-                        is_spend_note * (puzzle_note_app_data - encoded_puzzle_note_app_data),
+                        "check puzzle note app_data_static encoding",
+                        is_spend_note
+                            * (puzzle_note_app_data_static - encoded_puzzle_note_app_data_static),
                     ),
                 ],
             )
@@ -364,8 +368,8 @@ impl DealerIntentCheckConfig {
         puzzle_note_value: &AssignedCell<pallas::Base, pallas::Base>,
         sudoku_app_vk: &AssignedCell<pallas::Base, pallas::Base>,
         sudoku_app_vk_in_dealer_intent_note: &AssignedCell<pallas::Base, pallas::Base>,
-        puzzle_note_app_data: &AssignedCell<pallas::Base, pallas::Base>,
-        encoded_puzzle_note_app_data: &AssignedCell<pallas::Base, pallas::Base>,
+        puzzle_note_app_data_static: &AssignedCell<pallas::Base, pallas::Base>,
+        encoded_puzzle_note_app_data_static: &AssignedCell<pallas::Base, pallas::Base>,
         offset: usize,
         region: &mut Region<'_, pallas::Base>,
     ) -> Result<(), Error> {
@@ -386,16 +390,16 @@ impl DealerIntentCheckConfig {
             self.sudoku_app_vk_in_dealer_intent_note,
             offset,
         )?;
-        puzzle_note_app_data.copy_advice(
-            || "puzzle_note_app_data",
+        puzzle_note_app_data_static.copy_advice(
+            || "puzzle_note_app_data_static",
             region,
-            self.puzzle_note_app_data,
+            self.puzzle_note_app_data_static,
             offset,
         )?;
-        encoded_puzzle_note_app_data.copy_advice(
-            || "encoded_puzzle_note_app_data",
+        encoded_puzzle_note_app_data_static.copy_advice(
+            || "encoded_puzzle_note_app_data_static",
             region,
-            self.encoded_puzzle_note_app_data,
+            self.encoded_puzzle_note_app_data_static,
             offset,
         )?;
 

--- a/taiga_halo2/examples/taiga_sudoku/dealer_intent_app_vp.rs
+++ b/taiga_halo2/examples/taiga_sudoku/dealer_intent_app_vp.rs
@@ -24,7 +24,7 @@ use taiga_halo2::{
         note_circuit::NoteConfig,
         vp_circuit::{
             VPVerifyingInfo, ValidityPredicateCircuit, ValidityPredicateConfig,
-            ValidityPredicateInfo,
+            ValidityPredicateInfo, ValidityPredicateVerifyingInfo,
         },
     },
     constant::{NUM_NOTE, SETUP_PARAMS_MAP},
@@ -175,26 +175,6 @@ impl ValidityPredicateInfo for DealerIntentValidityPredicateCircuit {
         instances.push(self.is_spend_note);
 
         instances
-    }
-
-    fn get_verifying_info(&self) -> VPVerifyingInfo {
-        let mut rng = OsRng;
-        let params = SETUP_PARAMS_MAP.get(&12).unwrap();
-        let vk = keygen_vk(params, self).expect("keygen_vk should not fail");
-        let pk = keygen_pk(params, vk.clone(), self).expect("keygen_pk should not fail");
-        let instance = self.get_instances();
-        let proof = Proof::create(&pk, params, self.clone(), &[&instance], &mut rng).unwrap();
-        VPVerifyingInfo {
-            vk,
-            proof,
-            instance,
-        }
-    }
-
-    fn get_vp_description(&self) -> ValidityPredicateVerifyingKey {
-        let params = SETUP_PARAMS_MAP.get(&12).unwrap();
-        let vk = keygen_vk(params, self).expect("keygen_vk should not fail");
-        ValidityPredicateVerifyingKey::from_vk(vk)
     }
 }
 

--- a/taiga_halo2/examples/taiga_sudoku/gadgets/state_check.rs
+++ b/taiga_halo2/examples/taiga_sudoku/gadgets/state_check.rs
@@ -12,8 +12,8 @@ pub struct SudokuStateCheckConfig {
     q_state_check: Selector,
     is_spend_note: Column<Advice>,
     init_state: Column<Advice>,
-    spend_note_app_data: Column<Advice>,
-    spend_note_app_data_encoding: Column<Advice>,
+    spend_note_app_data_static: Column<Advice>,
+    spend_note_app_data_static_encoding: Column<Advice>,
     spend_note_vk: Column<Advice>,
     output_note_vk: Column<Advice>,
     spend_note_pre_state: Column<Advice>,
@@ -26,8 +26,8 @@ impl SudokuStateCheckConfig {
         meta: &mut ConstraintSystem<pallas::Base>,
         is_spend_note: Column<Advice>,
         init_state: Column<Advice>,
-        spend_note_app_data: Column<Advice>,
-        spend_note_app_data_encoding: Column<Advice>,
+        spend_note_app_data_static: Column<Advice>,
+        spend_note_app_data_static_encoding: Column<Advice>,
         spend_note_vk: Column<Advice>,
         output_note_vk: Column<Advice>,
         spend_note_pre_state: Column<Advice>,
@@ -35,8 +35,8 @@ impl SudokuStateCheckConfig {
     ) -> Self {
         meta.enable_equality(is_spend_note);
         meta.enable_equality(init_state);
-        meta.enable_equality(spend_note_app_data);
-        meta.enable_equality(spend_note_app_data_encoding);
+        meta.enable_equality(spend_note_app_data_static);
+        meta.enable_equality(spend_note_app_data_static_encoding);
         meta.enable_equality(spend_note_vk);
         meta.enable_equality(output_note_vk);
         meta.enable_equality(spend_note_pre_state);
@@ -46,8 +46,8 @@ impl SudokuStateCheckConfig {
             q_state_check: meta.selector(),
             is_spend_note,
             init_state,
-            spend_note_app_data,
-            spend_note_app_data_encoding,
+            spend_note_app_data_static,
+            spend_note_app_data_static_encoding,
             spend_note_vk,
             output_note_vk,
             spend_note_pre_state,
@@ -64,9 +64,10 @@ impl SudokuStateCheckConfig {
             let q_state_check = meta.query_selector(self.q_state_check);
             let is_spend_note = meta.query_advice(self.is_spend_note, Rotation::cur());
             let init_state = meta.query_advice(self.init_state, Rotation::cur());
-            let spend_note_app_data = meta.query_advice(self.spend_note_app_data, Rotation::cur());
-            let spend_note_app_data_encoding =
-                meta.query_advice(self.spend_note_app_data_encoding, Rotation::cur());
+            let spend_note_app_data_static =
+                meta.query_advice(self.spend_note_app_data_static, Rotation::cur());
+            let spend_note_app_data_static_encoding =
+                meta.query_advice(self.spend_note_app_data_static_encoding, Rotation::cur());
             let spend_note_vk = meta.query_advice(self.spend_note_vk, Rotation::cur());
             let output_note_vk = meta.query_advice(self.output_note_vk, Rotation::cur());
 
@@ -93,9 +94,9 @@ impl SudokuStateCheckConfig {
                         is_spend_note.clone() * (spend_note_vk.clone() - output_note_vk.clone()),
                     ),
                     (
-                        "check spend_note_app_data_encoding",
+                        "check spend_note_app_data_static_encoding",
                         is_spend_note.clone()
-                            * (spend_note_app_data_encoding - spend_note_app_data),
+                            * (spend_note_app_data_static_encoding - spend_note_app_data_static),
                     ),
                     (
                         "check puzzle init",
@@ -116,8 +117,8 @@ impl SudokuStateCheckConfig {
         &self,
         is_spend_note: &AssignedCell<pallas::Base, pallas::Base>,
         init_state: &AssignedCell<pallas::Base, pallas::Base>,
-        spend_note_app_data: &AssignedCell<pallas::Base, pallas::Base>,
-        spend_note_app_data_encoding: &AssignedCell<pallas::Base, pallas::Base>,
+        spend_note_app_data_static: &AssignedCell<pallas::Base, pallas::Base>,
+        spend_note_app_data_static_encoding: &AssignedCell<pallas::Base, pallas::Base>,
         spend_note_vk: &AssignedCell<pallas::Base, pallas::Base>,
         output_note_vk: &AssignedCell<pallas::Base, pallas::Base>,
         spend_note_pre_state: &AssignedCell<pallas::Base, pallas::Base>,
@@ -130,16 +131,16 @@ impl SudokuStateCheckConfig {
 
         is_spend_note.copy_advice(|| "is_spend_notex", region, self.is_spend_note, offset)?;
         init_state.copy_advice(|| "init_state", region, self.init_state, offset)?;
-        spend_note_app_data.copy_advice(
-            || "spend_note_app_data",
+        spend_note_app_data_static.copy_advice(
+            || "spend_note_app_data_static",
             region,
-            self.spend_note_app_data,
+            self.spend_note_app_data_static,
             offset,
         )?;
-        spend_note_app_data_encoding.copy_advice(
-            || "spend_note_app_data_encoding",
+        spend_note_app_data_static_encoding.copy_advice(
+            || "spend_note_app_data_static_encoding",
             region,
-            self.spend_note_app_data_encoding,
+            self.spend_note_app_data_static_encoding,
             offset,
         )?;
         spend_note_vk.copy_advice(|| "spend_note_vk", region, self.spend_note_vk, offset)?;

--- a/taiga_halo2/src/circuit/action_circuit.rs
+++ b/taiga_halo2/src/circuit/action_circuit.rs
@@ -190,10 +190,10 @@ impl Circuit<pallas::Base> for ActionCircuit {
             ecc_chip,
             config.hash_to_curve_config.clone(),
             spend_note_vars.app_vk.clone(),
-            spend_note_vars.app_data.clone(),
+            spend_note_vars.app_data_static.clone(),
             spend_note_vars.value.clone(),
             output_note_vars.app_vk.clone(),
-            output_note_vars.app_data.clone(),
+            output_note_vars.app_data_static.clone(),
             output_note_vars.value,
             self.rcv,
         )?;

--- a/taiga_halo2/src/circuit/vp_examples.rs
+++ b/taiga_halo2/src/circuit/vp_examples.rs
@@ -3,7 +3,7 @@ use crate::{
         note_circuit::NoteConfig,
         vp_circuit::{
             VPVerifyingInfo, ValidityPredicateCircuit, ValidityPredicateConfig,
-            ValidityPredicateInfo,
+            ValidityPredicateInfo, ValidityPredicateVerifyingInfo,
         },
     },
     constant::{NUM_NOTE, SETUP_PARAMS_MAP},
@@ -67,26 +67,6 @@ impl ValidityPredicateInfo for TrivialValidityPredicateCircuit {
 
     fn get_instances(&self) -> Vec<pallas::Base> {
         self.get_note_instances()
-    }
-
-    fn get_verifying_info(&self) -> VPVerifyingInfo {
-        let mut rng = OsRng;
-        let params = SETUP_PARAMS_MAP.get(&12).unwrap();
-        let vk = keygen_vk(params, self).expect("keygen_vk should not fail");
-        let pk = keygen_pk(params, vk.clone(), self).expect("keygen_pk should not fail");
-        let instance = self.get_instances();
-        let proof = Proof::create(&pk, params, self.clone(), &[&instance], &mut rng).unwrap();
-        VPVerifyingInfo {
-            vk,
-            proof,
-            instance,
-        }
-    }
-
-    fn get_vp_description(&self) -> ValidityPredicateVerifyingKey {
-        let params = SETUP_PARAMS_MAP.get(&12).unwrap();
-        let vk = keygen_vk(params, self).expect("keygen_vk should not fail");
-        ValidityPredicateVerifyingKey::from_vk(vk)
     }
 }
 

--- a/taiga_halo2/src/circuit/vp_examples/field_addition.rs
+++ b/taiga_halo2/src/circuit/vp_examples/field_addition.rs
@@ -8,7 +8,7 @@ use crate::{
         note_circuit::NoteConfig,
         vp_circuit::{
             VPVerifyingInfo, ValidityPredicateCircuit, ValidityPredicateConfig,
-            ValidityPredicateInfo,
+            ValidityPredicateInfo, ValidityPredicateVerifyingInfo,
         },
     },
     constant::{NUM_NOTE, SETUP_PARAMS_MAP},
@@ -95,26 +95,6 @@ impl ValidityPredicateInfo for FieldAdditionValidityPredicateCircuit {
         instances.push(self.a + self.b);
 
         instances
-    }
-
-    fn get_verifying_info(&self) -> VPVerifyingInfo {
-        let mut rng = OsRng;
-        let params = SETUP_PARAMS_MAP.get(&12).unwrap();
-        let vk = keygen_vk(params, self).expect("keygen_vk should not fail");
-        let pk = keygen_pk(params, vk.clone(), self).expect("keygen_pk should not fail");
-        let instance = self.get_instances();
-        let proof = Proof::create(&pk, params, self.clone(), &[&instance], &mut rng).unwrap();
-        VPVerifyingInfo {
-            vk,
-            proof,
-            instance,
-        }
-    }
-
-    fn get_vp_description(&self) -> ValidityPredicateVerifyingKey {
-        let params = SETUP_PARAMS_MAP.get(&12).unwrap();
-        let vk = keygen_vk(params, self).expect("keygen_vk should not fail");
-        ValidityPredicateVerifyingKey::from_vk(vk)
     }
 }
 

--- a/taiga_halo2/src/note.rs
+++ b/taiga_halo2/src/note.rs
@@ -1,5 +1,5 @@
 use crate::{
-    circuit::vp_circuit::ValidityPredicateInfo,
+    circuit::vp_circuit::ValidityPredicateVerifyingInfo,
     constant::{
         BASE_BITS_NUM, NOTE_COMMIT_DOMAIN, POSEIDON_TO_CURVE_INPUT_LEN, TAIGA_COMMITMENT_TREE_DEPTH,
     },
@@ -73,15 +73,15 @@ pub struct SpendNoteInfo {
     pub note: Note,
     pub auth_path: [(pallas::Base, LR); TAIGA_COMMITMENT_TREE_DEPTH],
     pub root: pallas::Base,
-    app_vp_proving_info: Box<dyn ValidityPredicateInfo>,
-    app_vp_proving_info_dynamic: Vec<Box<dyn ValidityPredicateInfo>>,
+    app_vp_verifying_info: Box<dyn ValidityPredicateVerifyingInfo>,
+    app_vp_verifying_info_dynamic: Vec<Box<dyn ValidityPredicateVerifyingInfo>>,
 }
 
 #[derive(Clone)]
 pub struct OutputNoteInfo {
     pub note: Note,
-    app_vp_proving_info: Box<dyn ValidityPredicateInfo>,
-    app_vp_proving_info_dynamic: Vec<Box<dyn ValidityPredicateInfo>>,
+    app_vp_verifying_info: Box<dyn ValidityPredicateVerifyingInfo>,
+    app_vp_verifying_info_dynamic: Vec<Box<dyn ValidityPredicateVerifyingInfo>>,
 }
 
 impl Note {
@@ -232,8 +232,8 @@ impl SpendNoteInfo {
     pub fn new(
         note: Note,
         merkle_path: MerklePath,
-        app_vp_proving_info: Box<dyn ValidityPredicateInfo>,
-        app_vp_proving_info_dynamic: Vec<Box<dyn ValidityPredicateInfo>>,
+        app_vp_verifying_info: Box<dyn ValidityPredicateVerifyingInfo>,
+        app_vp_verifying_info_dynamic: Vec<Box<dyn ValidityPredicateVerifyingInfo>>,
     ) -> Self {
         let cm_node = Node::new(note.commitment().get_x());
         let root = merkle_path.root(cm_node).inner();
@@ -243,50 +243,54 @@ impl SpendNoteInfo {
             note,
             auth_path,
             root,
-            app_vp_proving_info,
-            app_vp_proving_info_dynamic,
+            app_vp_verifying_info,
+            app_vp_verifying_info_dynamic,
         }
     }
 
-    pub fn get_app_vp_proving_info(&self) -> Box<dyn ValidityPredicateInfo> {
-        self.app_vp_proving_info.clone()
+    pub fn get_app_vp_verifying_info(&self) -> Box<dyn ValidityPredicateVerifyingInfo> {
+        self.app_vp_verifying_info.clone()
     }
 
-    pub fn get_app_vp_proving_info_dynamic(&self) -> Vec<Box<dyn ValidityPredicateInfo>> {
-        self.app_vp_proving_info_dynamic.clone()
+    pub fn get_app_vp_verifying_info_dynamic(
+        &self,
+    ) -> Vec<Box<dyn ValidityPredicateVerifyingInfo>> {
+        self.app_vp_verifying_info_dynamic.clone()
     }
 }
 
 impl OutputNoteInfo {
     pub fn new(
         note: Note,
-        app_vp_proving_info: Box<dyn ValidityPredicateInfo>,
-        app_vp_proving_info_dynamic: Vec<Box<dyn ValidityPredicateInfo>>,
+        app_vp_verifying_info: Box<dyn ValidityPredicateVerifyingInfo>,
+        app_vp_verifying_info_dynamic: Vec<Box<dyn ValidityPredicateVerifyingInfo>>,
     ) -> Self {
         Self {
             note,
-            app_vp_proving_info,
-            app_vp_proving_info_dynamic,
+            app_vp_verifying_info,
+            app_vp_verifying_info_dynamic,
         }
     }
 
     pub fn dummy<R: RngCore>(mut rng: R, nf: Nullifier) -> Self {
         use crate::circuit::vp_examples::TrivialValidityPredicateCircuit;
         let note = Note::dummy_from_rho(&mut rng, nf);
-        let app_vp_proving_info = Box::new(TrivialValidityPredicateCircuit::dummy(&mut rng));
-        let app_vp_proving_info_dynamic = vec![];
+        let app_vp_verifying_info = Box::new(TrivialValidityPredicateCircuit::dummy(&mut rng));
+        let app_vp_verifying_info_dynamic = vec![];
         Self {
             note,
-            app_vp_proving_info,
-            app_vp_proving_info_dynamic,
+            app_vp_verifying_info,
+            app_vp_verifying_info_dynamic,
         }
     }
 
-    pub fn get_app_vp_proving_info(&self) -> Box<dyn ValidityPredicateInfo> {
-        self.app_vp_proving_info.clone()
+    pub fn get_app_vp_verifying_info(&self) -> Box<dyn ValidityPredicateVerifyingInfo> {
+        self.app_vp_verifying_info.clone()
     }
 
-    pub fn get_app_vp_proving_info_dynamic(&self) -> Vec<Box<dyn ValidityPredicateInfo>> {
-        self.app_vp_proving_info_dynamic.clone()
+    pub fn get_app_vp_verifying_info_dynamic(
+        &self,
+    ) -> Vec<Box<dyn ValidityPredicateVerifyingInfo>> {
+        self.app_vp_verifying_info_dynamic.clone()
     }
 }

--- a/taiga_halo2/src/transaction.rs
+++ b/taiga_halo2/src/transaction.rs
@@ -84,7 +84,7 @@ pub struct ActionVerifyingInfo {
 #[derive(Debug, Clone)]
 pub struct NoteVPVerifyingInfoSet {
     app_vp_verifying_info: VPVerifyingInfo,
-    app_logic_vp_verifying_info: Vec<VPVerifyingInfo>,
+    app_dynamic_vp_verifying_info: Vec<VPVerifyingInfo>,
     // TODO: add verifier proof and according public inputs.
     // When the verifier proof is added, we may need to reconsider the structure of `VPVerifyingInfo`
 }
@@ -379,11 +379,11 @@ impl ActionVerifyingInfo {
 impl NoteVPVerifyingInfoSet {
     pub fn new(
         app_vp_verifying_info: VPVerifyingInfo,
-        app_logic_vp_verifying_info: Vec<VPVerifyingInfo>,
+        app_dynamic_vp_verifying_info: Vec<VPVerifyingInfo>,
     ) -> Self {
         Self {
             app_vp_verifying_info,
-            app_logic_vp_verifying_info,
+            app_dynamic_vp_verifying_info,
         }
     }
 
@@ -393,14 +393,14 @@ impl NoteVPVerifyingInfoSet {
     ) -> Self {
         let app_vp_verifying_info = app_vp_verifying_info.get_verifying_info();
 
-        let app_logic_vp_verifying_info = app_vp_verifying_info_dynamic
+        let app_dynamic_vp_verifying_info = app_vp_verifying_info_dynamic
             .into_iter()
             .map(|verifying_info| verifying_info.get_verifying_info())
             .collect();
 
         Self {
             app_vp_verifying_info,
-            app_logic_vp_verifying_info,
+            app_dynamic_vp_verifying_info,
         }
     }
 
@@ -408,8 +408,8 @@ impl NoteVPVerifyingInfoSet {
         // Verify application vp proof
         self.app_vp_verifying_info.verify()?;
 
-        // Verify application logic vp proofs
-        for verify_info in self.app_logic_vp_verifying_info.iter() {
+        // Verify application dynamic vp proofs
+        for verify_info in self.app_dynamic_vp_verifying_info.iter() {
             verify_info.verify()?;
         }
 
@@ -420,7 +420,7 @@ impl NoteVPVerifyingInfoSet {
 
     pub fn get_nullifiers(&self) -> Vec<[pallas::Base; NUM_NOTE]> {
         let mut nfs = vec![self.app_vp_verifying_info.get_nullifiers()];
-        self.app_logic_vp_verifying_info
+        self.app_dynamic_vp_verifying_info
             .iter()
             .for_each(|vp_info| nfs.push(vp_info.get_nullifiers()));
         nfs
@@ -428,7 +428,7 @@ impl NoteVPVerifyingInfoSet {
 
     pub fn get_note_commitments(&self) -> Vec<[pallas::Base; NUM_NOTE]> {
         let mut cms = vec![self.app_vp_verifying_info.get_note_commitments()];
-        self.app_logic_vp_verifying_info
+        self.app_dynamic_vp_verifying_info
             .iter()
             .for_each(|vp_info| cms.push(vp_info.get_note_commitments()));
         cms
@@ -457,14 +457,14 @@ fn test_transaction_creation() {
     // Generate notes
     let spend_note_1 = {
         let app_data_static = pallas::Base::zero();
-        // TODO: add real application logic vps and encode them to app_data_dynamic later.
-        let app_logic_vps_vk = vec![trivail_vp_vk.clone(), trivail_vp_vk.clone()];
-        // Encode the app_logic_vps_vk into app_data_dynamic
+        // TODO: add real application dynamic vps and encode them to app_data_dynamic later.
+        let app_dynamic_vp_vk = vec![trivail_vp_vk.clone(), trivail_vp_vk.clone()];
+        // Encode the app_dynamic_vp_vk into app_data_dynamic
         // The encoding method is flexible and defined in the application vp.
-        // Use poseidon hash to encode the two logic vps here
+        // Use poseidon hash to encode the two dynamic vps here
         let app_data_dynamic = poseidon_hash(
-            app_logic_vps_vk[0].get_compressed(),
-            app_logic_vps_vk[1].get_compressed(),
+            app_dynamic_vp_vk[0].get_compressed(),
+            app_dynamic_vp_vk[1].get_compressed(),
         );
         let app_vk = trivail_vp_vk.clone();
         let rho = Nullifier::new(pallas::Base::random(&mut rng));
@@ -487,8 +487,8 @@ fn test_transaction_creation() {
     };
     let output_note_1 = {
         let app_data_static = pallas::Base::zero();
-        // TODO: add real application logic vps and encode them to app_data_dynamic later.
-        // If the logic vp is not used, set app_data_dynamic pallas::Base::zero() by defualt.
+        // TODO: add real application dynamic vps and encode them to app_data_dynamic later.
+        // If the dynamic vp is not used, set app_data_dynamic pallas::Base::zero() by defualt.
         let app_data_dynamic = pallas::Base::zero();
         let rho = spend_note_1.get_nf().unwrap();
         let value = 5000u64;
@@ -519,17 +519,18 @@ fn test_transaction_creation() {
         output_notes: [output_note_1.clone(), output_note_2.clone()],
     };
     let app_vp_verifying_info = Box::new(trivial_vp_circuit.clone());
-    let trivial_app_logic_1: Box<dyn ValidityPredicateVerifyingInfo> =
+    let trivial_app_dynamic_vp_1: Box<dyn ValidityPredicateVerifyingInfo> =
         Box::new(trivial_vp_circuit.clone());
-    let trivial_app_logic_2 = Box::new(trivial_vp_circuit);
-    let trivial_app_vp_verifying_info_dynamic = vec![trivial_app_logic_1, trivial_app_logic_2];
+    let trivial_app_dynamic_vp_2 = Box::new(trivial_vp_circuit);
+    let trivial_app_vp_verifying_info_dynamic =
+        vec![trivial_app_dynamic_vp_1, trivial_app_dynamic_vp_2];
     let spend_note_info_1 = SpendNoteInfo::new(
         spend_note_1,
         merkle_path.clone(),
         app_vp_verifying_info.clone(),
         trivial_app_vp_verifying_info_dynamic.clone(),
     );
-    // The following notes use empty logic vps and use app_data_dynamic with pallas::Base::zero() by default.
+    // The following notes use empty dynamic vps and use app_data_dynamic with pallas::Base::zero() by default.
     let app_vp_verifying_info_dynamic = vec![];
     let spend_note_info_2 = SpendNoteInfo::new(
         spend_note_2,

--- a/taiga_halo2/src/transaction.rs
+++ b/taiga_halo2/src/transaction.rs
@@ -456,7 +456,7 @@ fn test_transaction_creation() {
 
     // Generate notes
     let spend_note_1 = {
-        let app_data = pallas::Base::zero();
+        let app_data_static = pallas::Base::zero();
         // TODO: add real application logic vps and encode them to app_data_dynamic later.
         let app_logic_vps_description = vec![
             trivail_vp_description.clone(),
@@ -478,7 +478,7 @@ fn test_transaction_creation() {
         let is_merkle_checked = true;
         Note::new(
             app_vk,
-            app_data,
+            app_data_static,
             app_data_dynamic,
             value,
             nk_com,
@@ -489,7 +489,7 @@ fn test_transaction_creation() {
         )
     };
     let output_note_1 = {
-        let app_data = pallas::Base::zero();
+        let app_data_static = pallas::Base::zero();
         // TODO: add real application logic vps and encode them to app_data_dynamic later.
         // If the logic vp is not used, set app_data_dynamic pallas::Base::zero() by defualt.
         let app_data_dynamic = pallas::Base::zero();
@@ -501,7 +501,7 @@ fn test_transaction_creation() {
         let is_merkle_checked = true;
         Note::new(
             trivail_vp_description,
-            app_data,
+            app_data_static,
             app_data_dynamic,
             value,
             nk_com,


### PR DESCRIPTION
- rename `app_data` to `app_data_static`
- rename `app_logic_vp` to `app_dynamic_vp` in transaction struct
- rename fn `get_vp_description` to `get_vp_vk`; vp_description is deprecated
- refine the `ValidityPredicateInfo` trait: add the new `ValidityPredicateVerifyingInfo` trait and the corresponding macro implementation to prevent duplicated code.