### PR TITLE
add the proof generation test for note encryption circuit

### DIFF
--- a/taiga_halo2/src/circuit/note_encryption_circuit.rs
+++ b/taiga_halo2/src/circuit/note_encryption_circuit.rs
@@ -121,9 +121,11 @@ fn test_halo2_note_encryption_circuit() {
     use crate::circuit::gadgets::add::AddConfig;
     use crate::circuit::gadgets::assign_free_advice;
     use crate::constant::{
-        NoteCommitmentDomain, NoteCommitmentFixedBases, NoteCommitmentHashDomain,
+        NoteCommitmentDomain, NoteCommitmentFixedBases, NoteCommitmentHashDomain, SETUP_PARAMS_MAP,
+        VP_CIRCUIT_PARAMS_SIZE,
     };
     use crate::note_encryption::{NoteCipher, SecretKey};
+    use crate::proof::Proof;
     use crate::utils::mod_r_p;
     use ff::Field;
     use group::Curve;
@@ -139,7 +141,7 @@ fn test_halo2_note_encryption_circuit() {
     use halo2_proofs::{
         circuit::{Layouter, SimpleFloorPlanner, Value},
         dev::MockProver,
-        plonk::{Advice, Circuit, Column, ConstraintSystem, Error},
+        plonk::{keygen_pk, keygen_vk, Advice, Circuit, Column, ConstraintSystem, Error},
     };
     use rand::rngs::OsRng;
 
@@ -351,5 +353,11 @@ fn test_halo2_note_encryption_circuit() {
     };
 
     let prover = MockProver::run(11, &circuit, vec![]).unwrap();
-    assert_eq!(prover.verify(), Ok(()))
+    assert_eq!(prover.verify(), Ok(()));
+
+    let params = SETUP_PARAMS_MAP.get(&VP_CIRCUIT_PARAMS_SIZE).unwrap();
+    let vk = keygen_vk(params, &circuit).expect("keygen_vk should not fail");
+    let pk = keygen_pk(params, vk.clone(), &circuit).expect("keygen_pk should not fail");
+    let proof = Proof::create(&pk, params, circuit, &[], &mut rng).unwrap();
+    assert!(proof.verify(&vk, params, &[]).is_ok());
 }


### PR DESCRIPTION
The proof generation bug was fixed in the halo2 dependency.