### PR TITLE
A receiver vp example

### DIFF
--- a/taiga_halo2/examples/tx_examples/cascaded_partial_transactions.rs
+++ b/taiga_halo2/examples/tx_examples/cascaded_partial_transactions.rs
@@ -101,6 +101,7 @@ pub fn create_transaction<R: RngCore + CryptoRng>(mut rng: R) -> Transaction {
 
         // Create the output note proving info
         let output_note_1_proving_info = generate_output_token_note_proving_info(
+            &mut rng,
             output_note_1,
             "btc".to_string(),
             bob_auth,
@@ -161,6 +162,7 @@ pub fn create_transaction<R: RngCore + CryptoRng>(mut rng: R) -> Transaction {
         );
         // Create the output note proving info
         let output_note_2_proving_info = generate_output_token_note_proving_info(
+            &mut rng,
             output_note_2,
             "eth".to_string(),
             bob_auth,
@@ -168,6 +170,7 @@ pub fn create_transaction<R: RngCore + CryptoRng>(mut rng: R) -> Transaction {
             output_notes,
         );
         let output_note_3_proving_info = generate_output_token_note_proving_info(
+            &mut rng,
             output_note_3,
             "xan".to_string(),
             bob_auth,

--- a/taiga_halo2/examples/tx_examples/partial_fulfillment_token_swap.rs
+++ b/taiga_halo2/examples/tx_examples/partial_fulfillment_token_swap.rs
@@ -197,6 +197,7 @@ pub fn consume_token_intent_ptx<R: RngCore>(
 
     // Create the output note proving info
     let bought_note_proving_info = generate_output_token_note_proving_info(
+        &mut rng,
         bought_note,
         buy.name,
         output_auth,
@@ -214,6 +215,7 @@ pub fn consume_token_intent_ptx<R: RngCore>(
 
     // Create the returned note proving info
     let returned_note_proving_info = generate_output_token_note_proving_info(
+        &mut rng,
         returned_note,
         sell.name,
         output_auth,

--- a/taiga_halo2/examples/tx_examples/token.rs
+++ b/taiga_halo2/examples/tx_examples/token.rs
@@ -105,6 +105,7 @@ pub fn create_token_swap_ptx<R: RngCore>(
 
     // Create the output note proving info
     let output_note_proving_info = generate_output_token_note_proving_info(
+        &mut rng,
         output_note,
         output_token.to_string(),
         output_auth,

--- a/taiga_halo2/examples/tx_examples/token_swap_with_intent.rs
+++ b/taiga_halo2/examples/tx_examples/token_swap_with_intent.rs
@@ -198,6 +198,7 @@ pub fn consume_token_intent_ptx<R: RngCore>(
 
     // Create the output note proving info
     let output_note_proving_info = generate_output_token_note_proving_info(
+        &mut rng,
         output_note,
         output_token.to_string(),
         output_auth,

--- a/taiga_halo2/src/circuit/integrity.rs
+++ b/taiga_halo2/src/circuit/integrity.rs
@@ -9,7 +9,7 @@ use crate::circuit::{
     vp_circuit::{InputNoteVariables, NoteVariables, OutputNoteVariables},
 };
 use crate::constant::{
-    BaseGenerator, NoteCommitmentDomain, NoteCommitmentHashDomain, TaigaFixedBases,
+    BaseFieldGenerators, NoteCommitmentDomain, NoteCommitmentHashDomain, TaigaFixedBases,
     TaigaFixedBasesFull, POSEIDON_TO_CURVE_INPUT_LEN,
 };
 use crate::note::Note;
@@ -62,7 +62,7 @@ pub fn nullifier_circuit(
         &psi,
     )?;
 
-    let nullifier_k = FixedPointBaseField::from_inner(ecc_chip, BaseGenerator);
+    let nullifier_k = FixedPointBaseField::from_inner(ecc_chip, BaseFieldGenerators::BaseGenerator);
     let hash_nk_rho_add_psi_mul_k = nullifier_k.mul(
         layouter.namespace(|| "hash_nk_rho_add_psi * nullifier_k"),
         hash_nk_rho_add_psi,

--- a/taiga_halo2/src/circuit/integrity.rs
+++ b/taiga_halo2/src/circuit/integrity.rs
@@ -164,9 +164,9 @@ pub fn check_input_note(
     )?;
 
     // Witness rcm
-    let rcm = ScalarFixed::new(
-        ecc_chip.clone(),
-        layouter.namespace(|| "rcm"),
+    let rcm = assign_free_advice(
+        layouter.namespace(|| "witness rcm"),
+        advices[0],
         Value::known(input_note.get_rcm()),
     )?;
 
@@ -189,7 +189,7 @@ pub fn check_input_note(
         rho.clone(),
         psi.clone(),
         value.clone(),
-        rcm,
+        rcm.clone(),
         is_merkle_checked.clone(),
     )?;
 
@@ -221,7 +221,7 @@ pub fn check_input_note(
         rho,
         nk_com,
         psi,
-        // rcm,
+        rcm,
     };
 
     Ok(InputNoteVariables {
@@ -293,9 +293,9 @@ pub fn check_output_note(
     )?;
 
     // Witness rcm
-    let rcm = ScalarFixed::new(
-        ecc_chip.clone(),
-        layouter.namespace(|| "rcm"),
+    let rcm = assign_free_advice(
+        layouter.namespace(|| "witness rcm"),
+        advices[0],
         Value::known(output_note.get_rcm()),
     )?;
 
@@ -325,7 +325,7 @@ pub fn check_output_note(
         old_nf.clone(),
         psi.clone(),
         value.clone(),
-        rcm,
+        rcm.clone(),
         is_merkle_checked.clone(),
     )?;
 
@@ -343,7 +343,7 @@ pub fn check_output_note(
         rho: old_nf,
         nk_com,
         psi,
-        // rcm,
+        rcm,
     };
 
     Ok(OutputNoteVariables {

--- a/taiga_halo2/src/circuit/note_encryption_circuit.rs
+++ b/taiga_halo2/src/circuit/note_encryption_circuit.rs
@@ -2,7 +2,7 @@ use crate::circuit::gadgets::{
     add::{AddChip, AddInstructions},
     assign_free_constant,
 };
-use crate::constant::{BaseGenerator, TaigaFixedBases, POSEIDON_RATE, POSEIDON_WIDTH};
+use crate::constant::{BaseFieldGenerators, TaigaFixedBases, POSEIDON_RATE, POSEIDON_WIDTH};
 use ff::PrimeField;
 use halo2_gadgets::{
     ecc::{chip::EccChip, FixedPointBaseField, NonIdentityPoint, Point, ScalarVar},
@@ -42,7 +42,7 @@ pub fn note_encryption_gadget(
         layouter.namespace(|| "ScalarVar from_base"),
         &sender_sk,
     )?;
-    let generator = FixedPointBaseField::from_inner(ecc_chip, BaseGenerator);
+    let generator = FixedPointBaseField::from_inner(ecc_chip, BaseFieldGenerators::BaseGenerator);
     let sender_pk = generator.mul(layouter.namespace(|| "sender_sk * generator"), sender_sk)?;
     let (secret_key, _) = rcv_pk.mul(layouter.namespace(|| "sender_sk * rcv_pk"), sk)?;
 

--- a/taiga_halo2/src/circuit/vp_circuit.rs
+++ b/taiga_halo2/src/circuit/vp_circuit.rs
@@ -241,6 +241,9 @@ pub struct NoteVariables {
     pub value: AssignedCell<pallas::Base, pallas::Base>,
     pub is_merkle_checked: AssignedCell<pallas::Base, pallas::Base>,
     pub app_data_dynamic: AssignedCell<pallas::Base, pallas::Base>,
+    pub rho: AssignedCell<pallas::Base, pallas::Base>,
+    pub nk_com: AssignedCell<pallas::Base, pallas::Base>,
+    pub psi: AssignedCell<pallas::Base, pallas::Base>,
 }
 
 // Variables in the input note
@@ -415,6 +418,72 @@ impl BasicValidityPredicateVariables {
             .map(|variables| NoteSearchableVariablePair {
                 src_variable: variables.cm_x.clone(),
                 target_variable: variables.note_variables.app_data_dynamic.clone(),
+            })
+            .collect();
+        input_note_pairs.extend(output_note_pairs);
+        input_note_pairs.try_into().unwrap()
+    }
+
+    pub fn get_rho_searchable_pairs(&self) -> [NoteSearchableVariablePair; NUM_NOTE * 2] {
+        let mut input_note_pairs: Vec<_> = self
+            .input_note_variables
+            .iter()
+            .map(|variables| NoteSearchableVariablePair {
+                src_variable: variables.nf.clone(),
+                target_variable: variables.note_variables.rho.clone(),
+            })
+            .collect();
+
+        let output_note_pairs: Vec<_> = self
+            .output_note_variables
+            .iter()
+            .map(|variables| NoteSearchableVariablePair {
+                src_variable: variables.cm_x.clone(),
+                target_variable: variables.note_variables.rho.clone(),
+            })
+            .collect();
+        input_note_pairs.extend(output_note_pairs);
+        input_note_pairs.try_into().unwrap()
+    }
+
+    pub fn get_nk_com_searchable_pairs(&self) -> [NoteSearchableVariablePair; NUM_NOTE * 2] {
+        let mut input_note_pairs: Vec<_> = self
+            .input_note_variables
+            .iter()
+            .map(|variables| NoteSearchableVariablePair {
+                src_variable: variables.nf.clone(),
+                target_variable: variables.note_variables.nk_com.clone(),
+            })
+            .collect();
+
+        let output_note_pairs: Vec<_> = self
+            .output_note_variables
+            .iter()
+            .map(|variables| NoteSearchableVariablePair {
+                src_variable: variables.cm_x.clone(),
+                target_variable: variables.note_variables.nk_com.clone(),
+            })
+            .collect();
+        input_note_pairs.extend(output_note_pairs);
+        input_note_pairs.try_into().unwrap()
+    }
+
+    pub fn get_psi_searchable_pairs(&self) -> [NoteSearchableVariablePair; NUM_NOTE * 2] {
+        let mut input_note_pairs: Vec<_> = self
+            .input_note_variables
+            .iter()
+            .map(|variables| NoteSearchableVariablePair {
+                src_variable: variables.nf.clone(),
+                target_variable: variables.note_variables.psi.clone(),
+            })
+            .collect();
+
+        let output_note_pairs: Vec<_> = self
+            .output_note_variables
+            .iter()
+            .map(|variables| NoteSearchableVariablePair {
+                src_variable: variables.cm_x.clone(),
+                target_variable: variables.note_variables.psi.clone(),
             })
             .collect();
         input_note_pairs.extend(output_note_pairs);

--- a/taiga_halo2/src/circuit/vp_circuit.rs
+++ b/taiga_halo2/src/circuit/vp_circuit.rs
@@ -244,6 +244,7 @@ pub struct NoteVariables {
     pub rho: AssignedCell<pallas::Base, pallas::Base>,
     pub nk_com: AssignedCell<pallas::Base, pallas::Base>,
     pub psi: AssignedCell<pallas::Base, pallas::Base>,
+    pub rcm: AssignedCell<pallas::Base, pallas::Base>,
 }
 
 // Variables in the input note
@@ -484,6 +485,28 @@ impl BasicValidityPredicateVariables {
             .map(|variables| NoteSearchableVariablePair {
                 src_variable: variables.cm_x.clone(),
                 target_variable: variables.note_variables.psi.clone(),
+            })
+            .collect();
+        input_note_pairs.extend(output_note_pairs);
+        input_note_pairs.try_into().unwrap()
+    }
+
+    pub fn get_rcm_searchable_pairs(&self) -> [NoteSearchableVariablePair; NUM_NOTE * 2] {
+        let mut input_note_pairs: Vec<_> = self
+            .input_note_variables
+            .iter()
+            .map(|variables| NoteSearchableVariablePair {
+                src_variable: variables.nf.clone(),
+                target_variable: variables.note_variables.rcm.clone(),
+            })
+            .collect();
+
+        let output_note_pairs: Vec<_> = self
+            .output_note_variables
+            .iter()
+            .map(|variables| NoteSearchableVariablePair {
+                src_variable: variables.cm_x.clone(),
+                target_variable: variables.note_variables.rcm.clone(),
             })
             .collect();
         input_note_pairs.extend(output_note_pairs);

--- a/taiga_halo2/src/circuit/vp_examples.rs
+++ b/taiga_halo2/src/circuit/vp_examples.rs
@@ -23,9 +23,9 @@ use rand::RngCore;
 
 pub mod cascade_intent;
 mod field_addition;
-mod note_encryption_example;
 pub mod or_relation_intent;
 pub mod partial_fulfillment_intent;
+pub mod receiver_vp;
 pub mod signature_verification;
 pub mod token;
 

--- a/taiga_halo2/src/circuit/vp_examples/receiver_vp.rs
+++ b/taiga_halo2/src/circuit/vp_examples/receiver_vp.rs
@@ -44,13 +44,14 @@ lazy_static! {
 // ReceiverValidityPredicateCircuit is used in the token vp as dynamic vp and contains the note encryption constraints.
 #[derive(Clone, Debug)]
 pub struct ReceiverValidityPredicateCircuit {
-    owned_note_pub_id: pallas::Base,
-    input_notes: [Note; NUM_NOTE],
-    output_notes: [Note; NUM_NOTE],
-    vp_vk: pallas::Base,
-    nonce: pallas::Base,
-    sk: pallas::Base,
-    rcv_pk: pallas::Point,
+    pub owned_note_pub_id: pallas::Base,
+    pub input_notes: [Note; NUM_NOTE],
+    pub output_notes: [Note; NUM_NOTE],
+    pub vp_vk: pallas::Base,
+    pub nonce: pallas::Base,
+    pub sk: pallas::Base,
+    pub rcv_pk: pallas::Point,
+    pub auth_vp_vk: pallas::Base,
 }
 
 impl Default for ReceiverValidityPredicateCircuit {
@@ -63,6 +64,7 @@ impl Default for ReceiverValidityPredicateCircuit {
             nonce: pallas::Base::zero(),
             sk: pallas::Base::zero(),
             rcv_pk: pallas::Point::generator(),
+            auth_vp_vk: pallas::Base::zero(),
         }
     }
 }
@@ -129,6 +131,7 @@ impl ReceiverValidityPredicateCircuit {
             nonce,
             sk,
             rcv_pk,
+            auth_vp_vk: *COMPRESSED_TOKEN_AUTH_VK,
         }
     }
 }

--- a/taiga_halo2/src/circuit/vp_examples/receiver_vp.rs
+++ b/taiga_halo2/src/circuit/vp_examples/receiver_vp.rs
@@ -162,6 +162,7 @@ impl ValidityPredicateInfo for ReceiverValidityPredicateCircuit {
             target_note.rho.inner(),
             target_note.nk_com.get_nk_com(),
             target_note.psi,
+            target_note.rcm,
         ];
         let key = SecretKey::from_dh_exchange(&self.rcv_pk, &mod_r_p(self.sk));
         let cipher = NoteCipher::encrypt(&message, &key, &self.nonce);
@@ -294,7 +295,14 @@ impl ValidityPredicateCircuit for ReceiverValidityPredicateCircuit {
             &basic_variables.get_psi_searchable_pairs(),
         )?;
 
-        let message = vec![app_data_static, app_vk, value, rho, nk_com, psi];
+        let rcm = get_owned_note_variable(
+            config.get_owned_note_variable_config,
+            layouter.namespace(|| "get owned note psi"),
+            &owned_note_pub_id,
+            &basic_variables.get_rcm_searchable_pairs(),
+        )?;
+
+        let message = vec![app_data_static, app_vk, value, rho, nk_com, psi, rcm];
 
         let add_chip = AddChip::<pallas::Base>::construct(config.add_config.clone(), ());
 

--- a/taiga_halo2/src/circuit/vp_examples/signature_verification.rs
+++ b/taiga_halo2/src/circuit/vp_examples/signature_verification.rs
@@ -10,7 +10,7 @@ use crate::{
             BasicValidityPredicateVariables, VPVerifyingInfo, ValidityPredicateCircuit,
             ValidityPredicateConfig, ValidityPredicateInfo, ValidityPredicateVerifyingInfo,
         },
-        // vp_examples::receiver_vp::COMPRESSED_RECEIVER_VK,
+        vp_examples::receiver_vp::COMPRESSED_RECEIVER_VK,
     },
     constant::{TaigaFixedBasesFull, NUM_NOTE, SETUP_PARAMS_MAP},
     note::Note,
@@ -95,9 +95,9 @@ pub struct SignatureVerificationValidityPredicateCircuit {
     pub owned_note_pub_id: pallas::Base,
     pub input_notes: [Note; NUM_NOTE],
     pub output_notes: [Note; NUM_NOTE],
-    // The compressed verifying_key and the pk are encoded in app_data_dynamic
-    pub verifying_key: pallas::Base,
+    pub vp_vk: pallas::Base,
     pub signature: SchnorrSignature,
+    pub receiver_vp_vk: pallas::Base,
 }
 
 #[derive(Clone, Debug)]
@@ -139,15 +139,17 @@ impl SignatureVerificationValidityPredicateCircuit {
         owned_note_pub_id: pallas::Base,
         input_notes: [Note; NUM_NOTE],
         output_notes: [Note; NUM_NOTE],
-        verifying_key: pallas::Base,
+        vp_vk: pallas::Base,
         signature: SchnorrSignature,
+        receiver_vp_vk: pallas::Base,
     ) -> Self {
         Self {
             owned_note_pub_id,
             input_notes,
             output_notes,
-            verifying_key,
+            vp_vk,
             signature,
+            receiver_vp_vk,
         }
     }
 
@@ -156,8 +158,9 @@ impl SignatureVerificationValidityPredicateCircuit {
         owned_note_pub_id: pallas::Base,
         input_notes: [Note; NUM_NOTE],
         output_notes: [Note; NUM_NOTE],
-        verifying_key: pallas::Base,
+        vp_vk: pallas::Base,
         sk: pallas::Scalar,
+        receiver_vp_vk: pallas::Base,
     ) -> Self {
         assert_eq!(NUM_NOTE, 2);
         let mut message = vec![];
@@ -175,8 +178,9 @@ impl SignatureVerificationValidityPredicateCircuit {
             owned_note_pub_id,
             input_notes,
             output_notes,
-            verifying_key,
+            vp_vk,
             signature,
+            receiver_vp_vk,
         }
     }
 
@@ -198,6 +202,7 @@ impl SignatureVerificationValidityPredicateCircuit {
             output_notes,
             auth_vk,
             sk,
+            *COMPRESSED_RECEIVER_VK,
         )
     }
 }
@@ -250,13 +255,12 @@ impl ValidityPredicateCircuit for SignatureVerificationValidityPredicateCircuit 
         let auth_vp_vk = assign_free_advice(
             layouter.namespace(|| "witness auth vp vk"),
             config.advices[0],
-            Value::known(self.verifying_key),
+            Value::known(self.vp_vk),
         )?;
         let receiver_vp_vk = assign_free_advice(
             layouter.namespace(|| "witness receiver vp vk"),
             config.advices[0],
-            // Value::known(*COMPRESSED_RECEIVER_VK),
-            Value::known(pallas::Base::zero()),
+            Value::known(self.receiver_vp_vk),
         )?;
 
         // Decode the app_data_dynamic, and check the app_data_dynamic encoding

--- a/taiga_halo2/src/circuit/vp_examples/token.rs
+++ b/taiga_halo2/src/circuit/vp_examples/token.rs
@@ -10,7 +10,7 @@ use crate::{
             BasicValidityPredicateVariables, VPVerifyingInfo, ValidityPredicateCircuit,
             ValidityPredicateConfig, ValidityPredicateInfo, ValidityPredicateVerifyingInfo,
         },
-        // vp_examples::receiver_vp::{COMPRESSED_RECEIVER_VK},
+        vp_examples::receiver_vp::{ReceiverValidityPredicateCircuit, COMPRESSED_RECEIVER_VK},
         vp_examples::signature_verification::{
             SignatureVerificationValidityPredicateCircuit, COMPRESSED_TOKEN_AUTH_VK,
         },
@@ -22,6 +22,7 @@ use crate::{
     utils::poseidon_hash_n,
     vp_vk::ValidityPredicateVerifyingKey,
 };
+use ff::Field;
 use group::{Curve, Group};
 use halo2_gadgets::ecc::{chip::EccChip, NonIdentityPoint};
 use halo2_proofs::{
@@ -31,8 +32,7 @@ use halo2_proofs::{
 use lazy_static::lazy_static;
 use pasta_curves::arithmetic::CurveAffine;
 use pasta_curves::{group::ff::PrimeField, pallas};
-use rand::rngs::OsRng;
-use rand::RngCore;
+use rand::{rngs::OsRng, Rng, RngCore};
 
 lazy_static! {
     pub static ref TOKEN_VK: ValidityPredicateVerifyingKey =
@@ -63,6 +63,7 @@ pub struct TokenValidityPredicateCircuit {
     pub token_name: String,
     // The auth goes to app_data_dynamic and defines how to consume and create the note.
     pub auth: TokenAuthorization,
+    pub receiver_vp_vk: pallas::Base,
 }
 
 #[derive(Clone, Debug, Copy)]
@@ -96,6 +97,7 @@ impl Default for TokenValidityPredicateCircuit {
             output_notes: [(); NUM_NOTE].map(|_| Note::default()),
             token_name: "Token_name".to_string(),
             auth: TokenAuthorization::default(),
+            receiver_vp_vk: pallas::Base::zero(),
         }
     }
 }
@@ -142,6 +144,7 @@ impl TokenValidityPredicateCircuit {
             output_notes,
             token_name,
             auth,
+            receiver_vp_vk: *COMPRESSED_RECEIVER_VK,
         }
     }
 }
@@ -223,8 +226,7 @@ impl ValidityPredicateCircuit for TokenValidityPredicateCircuit {
         let receiver_vp_vk = assign_free_advice(
             layouter.namespace(|| "witness receiver vp vk"),
             config.advices[0],
-            // Value::known(*COMPRESSED_RECEIVER_VK),
-            Value::known(pallas::Base::zero()),
+            Value::known(self.receiver_vp_vk),
         )?;
 
         // Decode the app_data_dynamic, and check the app_data_dynamic encoding
@@ -285,8 +287,7 @@ impl TokenAuthorization {
             *pk_coord.x(),
             *pk_coord.y(),
             self.vk,
-            // *COMPRESSED_RECEIVER_VK,
-            pallas::Base::zero(),
+            *COMPRESSED_RECEIVER_VK,
         ])
     }
 
@@ -316,6 +317,7 @@ pub fn generate_input_token_note_proving_info<R: RngCore>(
         output_notes,
         token_name,
         auth,
+        receiver_vp_vk: *COMPRESSED_RECEIVER_VK,
     };
 
     // token auth VP
@@ -326,6 +328,7 @@ pub fn generate_input_token_note_proving_info<R: RngCore>(
         output_notes,
         auth.vk,
         auth_sk,
+        *COMPRESSED_RECEIVER_VK,
     );
 
     // input note proving info
@@ -337,23 +340,38 @@ pub fn generate_input_token_note_proving_info<R: RngCore>(
     )
 }
 
-pub fn generate_output_token_note_proving_info(
+pub fn generate_output_token_note_proving_info<R: RngCore>(
+    mut rng: R,
     output_note: Note,
     token_name: String,
     auth: TokenAuthorization,
     input_notes: [Note; NUM_NOTE],
     output_notes: [Note; NUM_NOTE],
 ) -> OutputNoteProvingInfo {
+    let owned_note_pub_id = output_note.commitment().get_x();
     // token VP
     let token_vp = TokenValidityPredicateCircuit {
-        owned_note_pub_id: output_note.commitment().get_x(),
+        owned_note_pub_id,
         input_notes,
         output_notes,
         token_name,
         auth,
+        receiver_vp_vk: *COMPRESSED_RECEIVER_VK,
     };
 
-    OutputNoteProvingInfo::new(output_note, Box::new(token_vp), vec![])
+    // receiver VP
+    let receiver_vp = ReceiverValidityPredicateCircuit {
+        owned_note_pub_id,
+        input_notes,
+        output_notes,
+        vp_vk: *COMPRESSED_RECEIVER_VK,
+        nonce: pallas::Base::from_u128(rng.gen()),
+        sk: pallas::Base::random(&mut rng),
+        rcv_pk: auth.pk,
+        auth_vp_vk: *COMPRESSED_TOKEN_AUTH_VK,
+    };
+
+    OutputNoteProvingInfo::new(output_note, Box::new(token_vp), vec![Box::new(receiver_vp)])
 }
 
 #[test]

--- a/taiga_halo2/src/constant.rs
+++ b/taiga_halo2/src/constant.rs
@@ -5969,7 +5969,7 @@ pub struct TaigaFixedBases;
 impl FixedPoints<pallas::Affine> for TaigaFixedBases {
     type FullScalar = TaigaFixedBasesFull;
     type ShortScalar = Short;
-    type Base = BaseGenerator;
+    type Base = BaseFieldGenerators;
 }
 
 #[derive(Debug, Eq, PartialEq, Clone)]
@@ -6003,22 +6003,34 @@ impl FixedPoint<pallas::Affine> for TaigaFixedBasesFull {
     }
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub struct BaseGenerator;
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub enum BaseFieldGenerators {
+    NoteCommitmentR,
+    BaseGenerator,
+}
 
-impl FixedPoint<pallas::Affine> for BaseGenerator {
+impl FixedPoint<pallas::Affine> for BaseFieldGenerators {
     type FixedScalarKind = BaseFieldElem;
 
     fn generator(&self) -> pallas::Affine {
-        *GENERATOR
+        match self {
+            Self::NoteCommitmentR => *NOTE_COMMITMENT_R_GENERATOR,
+            Self::BaseGenerator => *GENERATOR,
+        }
     }
 
     fn u(&self) -> Vec<[[u8; 32]; H]> {
-        GENERATOR_U.to_vec()
+        match self {
+            Self::NoteCommitmentR => R_U.to_vec(),
+            Self::BaseGenerator => GENERATOR_U.to_vec(),
+        }
     }
 
     fn z(&self) -> Vec<u64> {
-        GENERATOR_Z.to_vec()
+        match self {
+            Self::NoteCommitmentR => R_Z.to_vec(),
+            Self::BaseGenerator => GENERATOR_Z.to_vec(),
+        }
     }
 }
 

--- a/taiga_halo2/src/note.rs
+++ b/taiga_halo2/src/note.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     merkle_tree::{MerklePath, Node, LR},
     nullifier::{Nullifier, NullifierDerivingKey, NullifierKeyCom},
-    utils::{extract_p, poseidon_hash, poseidon_to_curve},
+    utils::{extract_p, mod_r_p, poseidon_hash, poseidon_to_curve},
 };
 use bitvec::{array::BitArray, order::Lsb0};
 use blake2b_simd::Params as Blake2bParams;
@@ -62,7 +62,7 @@ pub struct Note {
     /// psi is to derive the nullifier
     pub psi: pallas::Base,
     /// rcm is the trapdoor of the note commitment
-    pub rcm: pallas::Scalar,
+    pub rcm: pallas::Base,
     /// If the is_merkle_checked flag is true, the merkle path authorization(membership) of input note will be checked in ActionProof.
     pub is_merkle_checked: bool,
 }
@@ -151,16 +151,15 @@ impl Note {
         let note_type = ValueBase::new(app_vk, app_data_static);
         let app_data_dynamic = pallas::Base::zero();
         let nk_com = NullifierKeyCom::rand(&mut rng);
-        let rcm = pallas::Scalar::random(&mut rng);
-        let psi = pallas::Base::random(&mut rng);
+        let rseed = RandomSeed::random(&mut rng);
         Self {
             note_type,
             app_data_dynamic,
             value: 0,
             nk_com,
             rho,
-            psi,
-            rcm,
+            psi: rseed.get_psi(&rho),
+            rcm: rseed.get_rcm(&rho),
             is_merkle_checked: false,
         }
     }
@@ -207,7 +206,7 @@ impl Note {
                             .iter()
                             .by_vals(),
                     ),
-                &self.get_rcm(),
+                &mod_r_p(self.get_rcm()),
             )
             .unwrap();
         NoteCommitment(ret)
@@ -252,7 +251,7 @@ impl Note {
         self.psi
     }
 
-    pub fn get_rcm(&self) -> pallas::Scalar {
+    pub fn get_rcm(&self) -> pallas::Base {
         self.rcm
     }
 }
@@ -294,7 +293,7 @@ impl RandomSeed {
         pallas::Base::from_uniform_bytes(&psi_bytes)
     }
 
-    pub fn get_rcm(&self, rho: &Nullifier) -> pallas::Scalar {
+    pub fn get_rcm(&self, rho: &Nullifier) -> pallas::Base {
         let mut h = Blake2bParams::new()
             .hash_length(64)
             .personal(PRF_EXPAND_PERSONALIZATION)
@@ -303,7 +302,7 @@ impl RandomSeed {
         h.update(&self.0);
         h.update(&rho.to_bytes());
         let rcm_bytes = *h.finalize().as_array();
-        pallas::Scalar::from_uniform_bytes(&rcm_bytes)
+        pallas::Base::from_uniform_bytes(&rcm_bytes)
     }
 }
 

--- a/taiga_halo2/src/nullifier.rs
+++ b/taiga_halo2/src/nullifier.rs
@@ -13,10 +13,10 @@ use rand::RngCore;
 #[derive(Copy, Debug, Clone, PartialEq, Eq)]
 pub struct Nullifier(pallas::Base);
 
-#[derive(Copy, Debug, Clone)]
+#[derive(Copy, Debug, Clone, PartialEq, Eq)]
 pub struct NullifierDerivingKey(pallas::Base);
 
-#[derive(Copy, Debug, Clone)]
+#[derive(Copy, Debug, Clone, PartialEq, Eq)]
 pub enum NullifierKeyCom {
     Closed(pallas::Base),
     Open(NullifierDerivingKey),


### PR DESCRIPTION
A receiver vp example that contains the note encryption constraints

- Added a receiver vp and used it in the token swap examples
- The note elements are encrypted in the receiver vp and can be recovered/decrypted from the instances/public inputs.

Note: To extract and encrypt the `rcm` which was a `ScalarFixed` type, I adjusted the sinsemilla commitment(`sinsemilla_commitment = sinsemilla_hash_to_point(msg) + rcm * {R}`). Now we use `sinsemilla_hash_to_point` from Halo2 and manually compute the `rcm * {R}` to construct the `rcm` from the Base field instead of the Scalar field.

We don't have a generic note decryption design because of the unfixed indexes ciphertext. I only give a specialized note decryption implementation for the receiver vp.