### PR TITLE
Unify configuration of VP circuits

### DIFF
--- a/taiga_halo2/src/circuit/vp_circuit.rs
+++ b/taiga_halo2/src/circuit/vp_circuit.rs
@@ -1,6 +1,14 @@
 use crate::{
     circuit::{
-        gadgets::{add::AddChip, assign_free_advice},
+        gadgets::{
+            add::{AddChip, AddConfig},
+            assign_free_advice,
+            conditional_equal::ConditionalEqualConfig,
+            extended_or_relation::ExtendedOrRelationConfig,
+            mul::{MulChip, MulConfig},
+            sub::{SubChip, SubConfig},
+            target_note_variable::{GetIsInputNoteFlagConfig, GetOwnedNoteVariableConfig},
+        },
         integrity::{check_input_note, check_output_note},
         note_circuit::{NoteChip, NoteCommitmentChip, NoteConfig},
     },
@@ -20,7 +28,10 @@ use dyn_clone::{clone_trait_object, DynClone};
 use halo2_gadgets::{ecc::chip::EccChip, sinsemilla::chip::SinsemillaChip};
 use halo2_proofs::{
     circuit::{AssignedCell, Layouter, Value},
-    plonk::{keygen_pk, keygen_vk, Circuit, ConstraintSystem, Error, VerifyingKey},
+    plonk::{
+        keygen_pk, keygen_vk, Advice, Circuit, Column, ConstraintSystem, Error, Instance,
+        VerifyingKey,
+    },
     poly::commitment::Params,
 };
 use pasta_curves::{pallas, vesta};
@@ -89,6 +100,65 @@ pub trait ValidityPredicateConfig {
     }
     fn get_note_config(&self) -> NoteConfig;
     fn configure(meta: &mut ConstraintSystem<pallas::Base>) -> Self;
+}
+
+#[derive(Clone, Debug)]
+pub struct GeneralVerificationValidityPredicateConfig {
+    pub note_conifg: NoteConfig,
+    pub advices: [Column<Advice>; 10],
+    pub instances: Column<Instance>,
+    pub get_is_input_note_flag_config: GetIsInputNoteFlagConfig,
+    pub get_owned_note_variable_config: GetOwnedNoteVariableConfig,
+    pub conditional_equal_config: ConditionalEqualConfig,
+    pub extended_or_relation_config: ExtendedOrRelationConfig,
+    pub add_config: AddConfig,
+    pub sub_config: SubConfig,
+    pub mul_config: MulConfig,
+}
+
+impl ValidityPredicateConfig for GeneralVerificationValidityPredicateConfig {
+    fn get_note_config(&self) -> NoteConfig {
+        self.note_conifg.clone()
+    }
+
+    fn configure(meta: &mut ConstraintSystem<pallas::Base>) -> Self {
+        let note_conifg = Self::configure_note(meta);
+
+        let advices = note_conifg.advices;
+        let instances = note_conifg.instances;
+
+        let get_owned_note_variable_config = GetOwnedNoteVariableConfig::configure(
+            meta,
+            advices[0],
+            [advices[1], advices[2], advices[3], advices[4]],
+        );
+
+        let get_is_input_note_flag_config =
+            GetIsInputNoteFlagConfig::configure(meta, advices[0], advices[1], advices[2]);
+
+        let conditional_equal_config =
+            ConditionalEqualConfig::configure(meta, [advices[0], advices[1], advices[2]]);
+
+        let add_config = note_conifg.add_config.clone();
+        let sub_config = SubChip::configure(meta, [advices[0], advices[1]]);
+        let mul_config = MulChip::configure(meta, [advices[0], advices[1]]);
+
+        let extended_or_relation_config =
+            ExtendedOrRelationConfig::configure(meta, [advices[0], advices[1], advices[2]]);
+
+        Self {
+            note_conifg,
+            advices,
+            instances,
+            get_is_input_note_flag_config,
+            get_owned_note_variable_config,
+            conditional_equal_config,
+            extended_or_relation_config,
+            add_config,
+            sub_config,
+            mul_config,
+        }
+    }
 }
 
 pub trait ValidityPredicateInfo {

--- a/taiga_halo2/src/circuit/vp_examples.rs
+++ b/taiga_halo2/src/circuit/vp_examples.rs
@@ -1,10 +1,7 @@
 use crate::{
-    circuit::{
-        note_circuit::NoteConfig,
-        vp_circuit::{
-            VPVerifyingInfo, ValidityPredicateCircuit, ValidityPredicateConfig,
-            ValidityPredicateInfo, ValidityPredicateVerifyingInfo,
-        },
+    circuit::vp_circuit::{
+        GeneralVerificationValidityPredicateConfig, VPVerifyingInfo, ValidityPredicateCircuit,
+        ValidityPredicateConfig, ValidityPredicateInfo, ValidityPredicateVerifyingInfo,
     },
     constant::{NUM_NOTE, SETUP_PARAMS_MAP},
     note::Note,
@@ -43,22 +40,6 @@ pub struct TrivialValidityPredicateCircuit {
     pub output_notes: [Note; NUM_NOTE],
 }
 
-#[derive(Clone, Debug)]
-pub struct DummyValidityPredicateConfig {
-    note_conifg: NoteConfig,
-}
-
-impl ValidityPredicateConfig for DummyValidityPredicateConfig {
-    fn get_note_config(&self) -> NoteConfig {
-        self.note_conifg.clone()
-    }
-
-    fn configure(meta: &mut ConstraintSystem<pallas::Base>) -> Self {
-        let note_conifg = Self::configure_note(meta);
-        Self { note_conifg }
-    }
-}
-
 impl TrivialValidityPredicateCircuit {
     pub fn dummy<R: RngCore>(mut rng: R) -> Self {
         let owned_note_pub_id = pallas::Base::zero();
@@ -91,7 +72,7 @@ impl ValidityPredicateInfo for TrivialValidityPredicateCircuit {
 }
 
 impl ValidityPredicateCircuit for TrivialValidityPredicateCircuit {
-    type VPConfig = DummyValidityPredicateConfig;
+    type VPConfig = GeneralVerificationValidityPredicateConfig;
 }
 
 vp_circuit_impl!(TrivialValidityPredicateCircuit);

--- a/taiga_halo2/src/circuit/vp_examples/field_addition.rs
+++ b/taiga_halo2/src/circuit/vp_examples/field_addition.rs
@@ -1,13 +1,13 @@
 use crate::{
     circuit::{
         gadgets::{
-            add::{AddChip, AddConfig, AddInstructions},
+            add::{AddChip, AddInstructions},
             assign_free_advice,
         },
-        note_circuit::NoteConfig,
         vp_circuit::{
-            BasicValidityPredicateVariables, VPVerifyingInfo, ValidityPredicateCircuit,
-            ValidityPredicateConfig, ValidityPredicateInfo, ValidityPredicateVerifyingInfo,
+            BasicValidityPredicateVariables, GeneralVerificationValidityPredicateConfig,
+            VPVerifyingInfo, ValidityPredicateCircuit, ValidityPredicateConfig,
+            ValidityPredicateInfo, ValidityPredicateVerifyingInfo,
         },
     },
     constant::{NUM_NOTE, SETUP_PARAMS_MAP, VP_CIRCUIT_CUSTOM_INSTANCE_BEGIN_IDX},
@@ -18,7 +18,7 @@ use crate::{
 use halo2_proofs::{
     arithmetic::Field,
     circuit::{floor_planner, Layouter, Value},
-    plonk::{keygen_pk, keygen_vk, Advice, Circuit, Column, ConstraintSystem, Error, Instance},
+    plonk::{keygen_pk, keygen_vk, Circuit, ConstraintSystem, Error},
 };
 use pasta_curves::pallas;
 use rand::rngs::OsRng;
@@ -32,37 +32,6 @@ struct FieldAdditionValidityPredicateCircuit {
     output_notes: [Note; NUM_NOTE],
     a: pallas::Base,
     b: pallas::Base,
-}
-
-#[derive(Clone, Debug)]
-struct FieldAdditionValidityPredicateConfig {
-    note_conifg: NoteConfig,
-    advices: [Column<Advice>; 10],
-    instances: Column<Instance>,
-    add_config: AddConfig,
-}
-
-impl ValidityPredicateConfig for FieldAdditionValidityPredicateConfig {
-    fn get_note_config(&self) -> NoteConfig {
-        self.note_conifg.clone()
-    }
-
-    fn configure(meta: &mut ConstraintSystem<pallas::Base>) -> Self {
-        let note_conifg = Self::configure_note(meta);
-
-        let advices = note_conifg.advices;
-        let instances = note_conifg.instances;
-
-        // configure custom config here
-        let add_config = note_conifg.add_config.clone();
-
-        Self {
-            note_conifg,
-            advices,
-            instances,
-            add_config,
-        }
-    }
 }
 
 impl FieldAdditionValidityPredicateCircuit {
@@ -105,7 +74,7 @@ impl ValidityPredicateInfo for FieldAdditionValidityPredicateCircuit {
 }
 
 impl ValidityPredicateCircuit for FieldAdditionValidityPredicateCircuit {
-    type VPConfig = FieldAdditionValidityPredicateConfig;
+    type VPConfig = GeneralVerificationValidityPredicateConfig;
     // Add custom constraints
     // Note: the trivial vp doesn't constrain on input_note_variables and output_note_variables
     fn custom_constraints(


### PR DESCRIPTION
close #184 
Keep the `ValidityPredicateConfig` trait, add the `GeneralVerificationValidityPredicateConfig`, and use the `GeneralVerificationValidityPredicateConfig` in all vp examples.