### PR TITLE
simplify the nullifier_key struct

### DIFF
--- a/taiga_halo2/examples/simple_sudoku/circuit.rs
+++ b/taiga_halo2/examples/simple_sudoku/circuit.rs
@@ -210,7 +210,7 @@ impl plonk::Circuit<pallas::Base> for SudokuCircuit {
                 layouter.namespace(|| "Poseidon init"),
             )?;
             poseidon_hasher.hash(
-                layouter.namespace(|| "Poseidon hash (nk, rho)"),
+                layouter.namespace(|| "Poseidon hash (x, y)"),
                 poseidon_message,
             )?
         };

--- a/taiga_halo2/examples/simple_sudoku/vp.rs
+++ b/taiga_halo2/examples/simple_sudoku/vp.rs
@@ -103,7 +103,7 @@ mod tests {
     use taiga_halo2::{
         constant::NUM_NOTE,
         note::{Note, RandomSeed},
-        nullifier::{Nullifier, NullifierKeyCom},
+        nullifier::{Nullifier, NullifierKeyContainer},
         vp_vk::ValidityPredicateVerifyingKey,
     };
 
@@ -147,7 +147,7 @@ mod tests {
         let app_data_dynamic = pallas::Base::zero();
 
         let value: u64 = 0;
-        let nk = NullifierKey::random(&mut rng);
+        let nk = NullifierKeyContainer::random_key(&mut rng);
         let rseed = RandomSeed::random(&mut rng);
         let rho = Nullifier::new(pallas::Base::random(&mut rng));
         Note::new(

--- a/taiga_halo2/examples/simple_sudoku/vp.rs
+++ b/taiga_halo2/examples/simple_sudoku/vp.rs
@@ -147,7 +147,7 @@ mod tests {
         let app_data_dynamic = pallas::Base::zero();
 
         let value: u64 = 0;
-        let nk_com = NullifierKeyCom::default();
+        let nk = NullifierKey::random(&mut rng);
         let rseed = RandomSeed::random(&mut rng);
         let rho = Nullifier::new(pallas::Base::random(&mut rng));
         Note::new(
@@ -155,7 +155,7 @@ mod tests {
             app_data_static,
             app_data_dynamic,
             value,
-            nk_com,
+            nk,
             rho,
             true,
             rseed,

--- a/taiga_halo2/examples/tx_examples/cascaded_partial_transactions.rs
+++ b/taiga_halo2/examples/tx_examples/cascaded_partial_transactions.rs
@@ -17,7 +17,7 @@ use taiga_halo2::{
     constant::TAIGA_COMMITMENT_TREE_DEPTH,
     merkle_tree::MerklePath,
     note::{InputNoteProvingInfo, OutputNoteProvingInfo},
-    nullifier::{Nullifier, NullifierKey},
+    nullifier::{Nullifier, NullifierKeyContainer},
     shielded_ptx::ShieldedPartialTransaction,
     transaction::{ShieldedPartialTxBundle, Transaction},
 };
@@ -25,10 +25,10 @@ use taiga_halo2::{
 pub fn create_transaction<R: RngCore + CryptoRng>(mut rng: R) -> Transaction {
     let alice_auth_sk = pallas::Scalar::random(&mut rng);
     let alice_auth = TokenAuthorization::from_sk_vk(&alice_auth_sk, &COMPRESSED_TOKEN_AUTH_VK);
-    let alice_nk = NullifierKey::random(&mut rng);
+    let alice_nk = NullifierKeyContainer::random_key(&mut rng);
 
     let bob_auth = TokenAuthorization::random(&mut rng);
-    let bob_nk = NullifierKey::random(&mut rng);
+    let bob_nk_com = NullifierKeyContainer::random_commitment(&mut rng);
 
     let rho = Nullifier::new(pallas::Base::random(&mut rng));
     let input_note_1 = create_random_token_note(&mut rng, "btc", 1u64, rho, alice_nk, &alice_auth);
@@ -37,7 +37,7 @@ pub fn create_transaction<R: RngCore + CryptoRng>(mut rng: R) -> Transaction {
         "btc",
         1u64,
         input_note_1.get_nf().unwrap(),
-        bob_nk,
+        bob_nk_com,
         &bob_auth,
     );
     let input_note_2 = create_random_token_note(&mut rng, "eth", 2u64, rho, alice_nk, &alice_auth);
@@ -54,7 +54,7 @@ pub fn create_transaction<R: RngCore + CryptoRng>(mut rng: R) -> Transaction {
         "eth",
         2u64,
         cascade_intent_note.get_nf().unwrap(),
-        bob_nk,
+        bob_nk_com,
         &bob_auth,
     );
     let output_note_3 = create_random_token_note(
@@ -62,7 +62,7 @@ pub fn create_transaction<R: RngCore + CryptoRng>(mut rng: R) -> Transaction {
         "xan",
         3u64,
         input_note_3.get_nf().unwrap(),
-        bob_nk,
+        bob_nk_com,
         &bob_auth,
     );
 

--- a/taiga_halo2/examples/tx_examples/cascaded_partial_transactions.rs
+++ b/taiga_halo2/examples/tx_examples/cascaded_partial_transactions.rs
@@ -17,7 +17,7 @@ use taiga_halo2::{
     constant::TAIGA_COMMITMENT_TREE_DEPTH,
     merkle_tree::MerklePath,
     note::{InputNoteProvingInfo, OutputNoteProvingInfo},
-    nullifier::{Nullifier, NullifierKeyCom},
+    nullifier::{Nullifier, NullifierKey},
     shielded_ptx::ShieldedPartialTransaction,
     transaction::{ShieldedPartialTxBundle, Transaction},
 };
@@ -25,39 +25,36 @@ use taiga_halo2::{
 pub fn create_transaction<R: RngCore + CryptoRng>(mut rng: R) -> Transaction {
     let alice_auth_sk = pallas::Scalar::random(&mut rng);
     let alice_auth = TokenAuthorization::from_sk_vk(&alice_auth_sk, &COMPRESSED_TOKEN_AUTH_VK);
-    let alice_nk_com = NullifierKeyCom::rand(&mut rng);
+    let alice_nk = NullifierKey::random(&mut rng);
 
     let bob_auth = TokenAuthorization::random(&mut rng);
-    let bob_nk_com = NullifierKeyCom::rand(&mut rng);
+    let bob_nk = NullifierKey::random(&mut rng);
 
     let rho = Nullifier::new(pallas::Base::random(&mut rng));
-    let input_note_1 =
-        create_random_token_note(&mut rng, "btc", 1u64, rho, alice_nk_com, &alice_auth);
+    let input_note_1 = create_random_token_note(&mut rng, "btc", 1u64, rho, alice_nk, &alice_auth);
     let output_note_1 = create_random_token_note(
         &mut rng,
         "btc",
         1u64,
         input_note_1.get_nf().unwrap(),
-        bob_nk_com,
+        bob_nk,
         &bob_auth,
     );
-    let input_note_2 =
-        create_random_token_note(&mut rng, "eth", 2u64, rho, alice_nk_com, &alice_auth);
+    let input_note_2 = create_random_token_note(&mut rng, "eth", 2u64, rho, alice_nk, &alice_auth);
 
-    let input_note_3 =
-        create_random_token_note(&mut rng, "xan", 3u64, rho, alice_nk_com, &alice_auth);
+    let input_note_3 = create_random_token_note(&mut rng, "xan", 3u64, rho, alice_nk, &alice_auth);
     let cascade_intent_note = create_intent_note(
         &mut rng,
         input_note_3.commitment().get_x(),
         input_note_2.get_nf().unwrap(),
-        alice_nk_com,
+        alice_nk,
     );
     let output_note_2 = create_random_token_note(
         &mut rng,
         "eth",
         2u64,
         cascade_intent_note.get_nf().unwrap(),
-        bob_nk_com,
+        bob_nk,
         &bob_auth,
     );
     let output_note_3 = create_random_token_note(
@@ -65,7 +62,7 @@ pub fn create_transaction<R: RngCore + CryptoRng>(mut rng: R) -> Transaction {
         "xan",
         3u64,
         input_note_3.get_nf().unwrap(),
-        bob_nk_com,
+        bob_nk,
         &bob_auth,
     );
 

--- a/taiga_halo2/examples/tx_examples/partial_fulfillment_token_swap.rs
+++ b/taiga_halo2/examples/tx_examples/partial_fulfillment_token_swap.rs
@@ -22,7 +22,7 @@ use taiga_halo2::{
     constant::TAIGA_COMMITMENT_TREE_DEPTH,
     merkle_tree::MerklePath,
     note::{InputNoteProvingInfo, Note, OutputNoteProvingInfo},
-    nullifier::{Nullifier, NullifierKey},
+    nullifier::{Nullifier, NullifierKeyContainer},
     shielded_ptx::ShieldedPartialTransaction,
     transaction::{ShieldedPartialTxBundle, Transaction},
 };
@@ -32,11 +32,11 @@ pub fn create_token_intent_ptx<R: RngCore>(
     sell: Token,
     buy: Token,
     input_auth_sk: pallas::Scalar,
-    input_nk: NullifierKey, // NullifierKey::Open
+    input_nk: NullifierKeyContainer, // NullifierKeyContainer::Key
 ) -> (
     ShieldedPartialTransaction,
     pallas::Scalar,
-    NullifierKey,
+    NullifierKeyContainer,
     pallas::Base,
     Nullifier,
 ) {
@@ -129,7 +129,7 @@ pub fn consume_token_intent_ptx<R: RngCore>(
     bought_note_value: u64,
     returned_note_value: u64,
     input_rho: Nullifier,
-    input_nk: NullifierKey,
+    input_nk: NullifierKeyContainer, // NullifierKeyContainer::Key
     input_address: pallas::Base,
     output_auth_pk: pallas::Point,
 ) -> (ShieldedPartialTransaction, pallas::Scalar) {
@@ -230,7 +230,7 @@ pub fn create_token_swap_transaction<R: RngCore + CryptoRng>(mut rng: R) -> Tran
     // Alice creates the partial transaction with 5 BTC input and intent output
     let alice_auth_sk = pallas::Scalar::random(&mut rng);
     let alice_auth_pk = generator * alice_auth_sk;
-    let alice_nk = NullifierKey::random(&mut rng);
+    let alice_nk = NullifierKeyContainer::random_key(&mut rng);
     let sell = Token {
         name: "btc".to_string(),
         value: 2u64,
@@ -245,7 +245,7 @@ pub fn create_token_swap_transaction<R: RngCore + CryptoRng>(mut rng: R) -> Tran
     // Bob creates the partial transaction with 1 DOLPHIN input and 5 BTC output
     let bob_auth_sk = pallas::Scalar::random(&mut rng);
     let bob_auth_pk = generator * bob_auth_sk;
-    let bob_nk = NullifierKey::random(&mut rng);
+    let bob_nk = NullifierKeyContainer::random_key(&mut rng);
 
     let (bob_ptx, bob_r) = create_token_swap_ptx(
         &mut rng,
@@ -256,7 +256,7 @@ pub fn create_token_swap_transaction<R: RngCore + CryptoRng>(mut rng: R) -> Tran
         "btc",
         1,
         bob_auth_pk,
-        bob_nk,
+        bob_nk.to_commitment(),
     );
 
     // Solver/Bob creates the partial transaction to consume the intent note

--- a/taiga_halo2/examples/tx_examples/partial_fulfillment_token_swap.rs
+++ b/taiga_halo2/examples/tx_examples/partial_fulfillment_token_swap.rs
@@ -22,7 +22,7 @@ use taiga_halo2::{
     constant::TAIGA_COMMITMENT_TREE_DEPTH,
     merkle_tree::MerklePath,
     note::{InputNoteProvingInfo, Note, OutputNoteProvingInfo},
-    nullifier::{Nullifier, NullifierDerivingKey, NullifierKeyCom},
+    nullifier::{Nullifier, NullifierKey},
     shielded_ptx::ShieldedPartialTransaction,
     transaction::{ShieldedPartialTxBundle, Transaction},
 };
@@ -32,11 +32,11 @@ pub fn create_token_intent_ptx<R: RngCore>(
     sell: Token,
     buy: Token,
     input_auth_sk: pallas::Scalar,
-    input_nk: NullifierDerivingKey, // NullifierKeyCom::Open
+    input_nk: NullifierKey, // NullifierKey::Open
 ) -> (
     ShieldedPartialTransaction,
     pallas::Scalar,
-    NullifierKeyCom,
+    NullifierKey,
     pallas::Base,
     Nullifier,
 ) {
@@ -44,15 +44,8 @@ pub fn create_token_intent_ptx<R: RngCore>(
 
     // input note
     let rho = Nullifier::new(pallas::Base::random(&mut rng));
-    let input_nk_com = NullifierKeyCom::from_open(input_nk);
-    let input_note = create_random_token_note(
-        &mut rng,
-        &sell.name,
-        sell.value,
-        rho,
-        input_nk_com,
-        &input_auth,
-    );
+    let input_note =
+        create_random_token_note(&mut rng, &sell.name, sell.value, rho, input_nk, &input_auth);
 
     // output intent note
     // Use the same address as that in the input note. They can be different.
@@ -64,7 +57,7 @@ pub fn create_token_intent_ptx<R: RngCore>(
         &buy,
         receiver_address,
         input_note_nf,
-        input_nk_com,
+        input_nk,
     );
 
     // padding the zero notes
@@ -125,7 +118,7 @@ pub fn create_token_intent_ptx<R: RngCore>(
         &mut rng,
     );
 
-    (ptx, r, input_nk_com, receiver_address, rho)
+    (ptx, r, input_nk, receiver_address, rho)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -136,7 +129,7 @@ pub fn consume_token_intent_ptx<R: RngCore>(
     bought_note_value: u64,
     returned_note_value: u64,
     input_rho: Nullifier,
-    input_nk: NullifierKeyCom,
+    input_nk: NullifierKey,
     input_address: pallas::Base,
     output_auth_pk: pallas::Point,
 ) -> (ShieldedPartialTransaction, pallas::Scalar) {
@@ -237,8 +230,7 @@ pub fn create_token_swap_transaction<R: RngCore + CryptoRng>(mut rng: R) -> Tran
     // Alice creates the partial transaction with 5 BTC input and intent output
     let alice_auth_sk = pallas::Scalar::random(&mut rng);
     let alice_auth_pk = generator * alice_auth_sk;
-    let alice_nk_com = NullifierKeyCom::rand(&mut rng);
-    let alice_nk = alice_nk_com.get_nk().unwrap();
+    let alice_nk = NullifierKey::random(&mut rng);
     let sell = Token {
         name: "btc".to_string(),
         value: 2u64,
@@ -253,8 +245,7 @@ pub fn create_token_swap_transaction<R: RngCore + CryptoRng>(mut rng: R) -> Tran
     // Bob creates the partial transaction with 1 DOLPHIN input and 5 BTC output
     let bob_auth_sk = pallas::Scalar::random(&mut rng);
     let bob_auth_pk = generator * bob_auth_sk;
-    let bob_nk_com = NullifierKeyCom::rand(&mut rng);
-    let bob_nk = bob_nk_com.get_nk().unwrap();
+    let bob_nk = NullifierKey::random(&mut rng);
 
     let (bob_ptx, bob_r) = create_token_swap_ptx(
         &mut rng,
@@ -265,7 +256,7 @@ pub fn create_token_swap_transaction<R: RngCore + CryptoRng>(mut rng: R) -> Tran
         "btc",
         1,
         bob_auth_pk,
-        bob_nk_com.get_nk_com(),
+        bob_nk,
     );
 
     // Solver/Bob creates the partial transaction to consume the intent note

--- a/taiga_halo2/examples/tx_examples/token.rs
+++ b/taiga_halo2/examples/tx_examples/token.rs
@@ -14,7 +14,7 @@ use taiga_halo2::{
     constant::TAIGA_COMMITMENT_TREE_DEPTH,
     merkle_tree::MerklePath,
     note::{InputNoteProvingInfo, Note, OutputNoteProvingInfo, RandomSeed},
-    nullifier::{Nullifier, NullifierKey},
+    nullifier::{Nullifier, NullifierKeyContainer},
     shielded_ptx::ShieldedPartialTransaction,
 };
 
@@ -23,7 +23,7 @@ pub fn create_random_token_note<R: RngCore>(
     name: &str,
     value: u64,
     rho: Nullifier,
-    nk: NullifierKey,
+    nk_container: NullifierKeyContainer,
     auth: &TokenAuthorization,
 ) -> Note {
     let app_data_static = transfrom_token_name_to_token_property(name);
@@ -34,7 +34,7 @@ pub fn create_random_token_note<R: RngCore>(
         app_data_static,
         app_data_dynamic,
         value,
-        nk,
+        nk_container,
         rho,
         true,
         rseed,
@@ -47,11 +47,11 @@ pub fn create_token_swap_ptx<R: RngCore>(
     input_token: &str,
     input_value: u64,
     input_auth_sk: pallas::Scalar,
-    input_nk: NullifierKey, // NullifierKey::Open
+    input_nk: NullifierKeyContainer, // NullifierKeyContainer::Key
     output_token: &str,
     output_value: u64,
     output_auth_pk: pallas::Point,
-    output_nk: NullifierKey, // NullifierKey::Closed
+    output_nk_com: NullifierKeyContainer, // NullifierKeyContainer::Commitment
 ) -> (ShieldedPartialTransaction, pallas::Scalar) {
     let input_auth = TokenAuthorization::from_sk_vk(&input_auth_sk, &COMPRESSED_TOKEN_AUTH_VK);
 
@@ -74,7 +74,7 @@ pub fn create_token_swap_ptx<R: RngCore>(
         output_token,
         output_value,
         input_note_nf,
-        output_nk,
+        output_nk_com,
         &output_auth,
     );
 

--- a/taiga_halo2/examples/tx_examples/token.rs
+++ b/taiga_halo2/examples/tx_examples/token.rs
@@ -14,7 +14,7 @@ use taiga_halo2::{
     constant::TAIGA_COMMITMENT_TREE_DEPTH,
     merkle_tree::MerklePath,
     note::{InputNoteProvingInfo, Note, OutputNoteProvingInfo, RandomSeed},
-    nullifier::{Nullifier, NullifierDerivingKey, NullifierKeyCom},
+    nullifier::{Nullifier, NullifierKey},
     shielded_ptx::ShieldedPartialTransaction,
 };
 
@@ -23,7 +23,7 @@ pub fn create_random_token_note<R: RngCore>(
     name: &str,
     value: u64,
     rho: Nullifier,
-    nk_com: NullifierKeyCom,
+    nk: NullifierKey,
     auth: &TokenAuthorization,
 ) -> Note {
     let app_data_static = transfrom_token_name_to_token_property(name);
@@ -34,7 +34,7 @@ pub fn create_random_token_note<R: RngCore>(
         app_data_static,
         app_data_dynamic,
         value,
-        nk_com,
+        nk,
         rho,
         true,
         rseed,
@@ -47,36 +47,34 @@ pub fn create_token_swap_ptx<R: RngCore>(
     input_token: &str,
     input_value: u64,
     input_auth_sk: pallas::Scalar,
-    input_nk: NullifierDerivingKey, // NullifierKeyCom::Open
+    input_nk: NullifierKey, // NullifierKey::Open
     output_token: &str,
     output_value: u64,
     output_auth_pk: pallas::Point,
-    output_nk_com: pallas::Base, // NullifierKeyCom::Closed
+    output_nk: NullifierKey, // NullifierKey::Closed
 ) -> (ShieldedPartialTransaction, pallas::Scalar) {
     let input_auth = TokenAuthorization::from_sk_vk(&input_auth_sk, &COMPRESSED_TOKEN_AUTH_VK);
 
     // input note
     let rho = Nullifier::new(pallas::Base::random(&mut rng));
-    let input_nk_com = NullifierKeyCom::from_open(input_nk);
     let input_note = create_random_token_note(
         &mut rng,
         input_token,
         input_value,
         rho,
-        input_nk_com,
+        input_nk,
         &input_auth,
     );
 
     // output note
     let input_note_nf = input_note.get_nf().unwrap();
     let output_auth = TokenAuthorization::new(output_auth_pk, *COMPRESSED_TOKEN_AUTH_VK);
-    let output_nk_com = NullifierKeyCom::from_closed(output_nk_com);
     let output_note = create_random_token_note(
         &mut rng,
         output_token,
         output_value,
         input_note_nf,
-        output_nk_com,
+        output_nk,
         &output_auth,
     );
 

--- a/taiga_halo2/examples/tx_examples/token_swap_with_intent.rs
+++ b/taiga_halo2/examples/tx_examples/token_swap_with_intent.rs
@@ -22,7 +22,7 @@ use taiga_halo2::{
     constant::TAIGA_COMMITMENT_TREE_DEPTH,
     merkle_tree::MerklePath,
     note::{InputNoteProvingInfo, Note, OutputNoteProvingInfo},
-    nullifier::{Nullifier, NullifierDerivingKey, NullifierKeyCom},
+    nullifier::{Nullifier, NullifierKey},
     shielded_ptx::ShieldedPartialTransaction,
     transaction::{ShieldedPartialTxBundle, Transaction},
 };
@@ -34,11 +34,11 @@ pub fn create_token_intent_ptx<R: RngCore>(
     input_token: &str,
     input_value: u64,
     input_auth_sk: pallas::Scalar,
-    input_nk: NullifierDerivingKey, // NullifierKeyCom::Open
+    input_nk: NullifierKey, // NullifierKey::Open
 ) -> (
     ShieldedPartialTransaction,
     pallas::Scalar,
-    NullifierKeyCom,
+    NullifierKey,
     pallas::Base,
     Nullifier,
 ) {
@@ -46,13 +46,12 @@ pub fn create_token_intent_ptx<R: RngCore>(
 
     // input note
     let rho = Nullifier::new(pallas::Base::random(&mut rng));
-    let input_nk_com = NullifierKeyCom::from_open(input_nk);
     let input_note = create_random_token_note(
         &mut rng,
         input_token,
         input_value,
         rho,
-        input_nk_com,
+        input_nk,
         &input_auth,
     );
 
@@ -66,7 +65,7 @@ pub fn create_token_intent_ptx<R: RngCore>(
         &condition2,
         receiver_address,
         input_note_nf,
-        input_nk_com,
+        input_nk,
     );
 
     // padding the zero notes
@@ -127,7 +126,7 @@ pub fn create_token_intent_ptx<R: RngCore>(
         &mut rng,
     );
 
-    (ptx, r, input_nk_com, receiver_address, rho)
+    (ptx, r, input_nk, receiver_address, rho)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -136,7 +135,7 @@ pub fn consume_token_intent_ptx<R: RngCore>(
     condition1: Condition,
     condition2: Condition,
     input_rho: Nullifier,
-    input_nk: NullifierKeyCom,
+    input_nk: NullifierKey,
     input_address: pallas::Base,
     output_token: &str,
     output_value: u64,
@@ -235,8 +234,7 @@ pub fn create_token_swap_intent_transaction<R: RngCore + CryptoRng>(mut rng: R) 
     // Alice creates the partial transaction with 5 BTC input and intent output
     let alice_auth_sk = pallas::Scalar::random(&mut rng);
     let alice_auth_pk = generator * alice_auth_sk;
-    let alice_nk_com = NullifierKeyCom::rand(&mut rng);
-    let alice_nk = alice_nk_com.get_nk().unwrap();
+    let alice_nk = NullifierKey::random(&mut rng);
     let condition1 = Condition {
         token_name: "dolphin".to_string(),
         token_value: 1u64,
@@ -258,8 +256,7 @@ pub fn create_token_swap_intent_transaction<R: RngCore + CryptoRng>(mut rng: R) 
     // Bob creates the partial transaction with 1 DOLPHIN input and 5 BTC output
     let bob_auth_sk = pallas::Scalar::random(&mut rng);
     let bob_auth_pk = generator * bob_auth_sk;
-    let bob_nk_com = NullifierKeyCom::rand(&mut rng);
-    let bob_nk = bob_nk_com.get_nk().unwrap();
+    let bob_nk = NullifierKey::random(&mut rng);
 
     let (bob_ptx, bob_r) = create_token_swap_ptx(
         &mut rng,
@@ -270,7 +267,7 @@ pub fn create_token_swap_intent_transaction<R: RngCore + CryptoRng>(mut rng: R) 
         "btc",
         5,
         bob_auth_pk,
-        bob_nk_com.get_nk_com(),
+        bob_nk,
     );
 
     // Solver/Bob creates the partial transaction to consume the intent note

--- a/taiga_halo2/examples/tx_examples/token_swap_without_intent.rs
+++ b/taiga_halo2/examples/tx_examples/token_swap_without_intent.rs
@@ -9,7 +9,7 @@ use halo2_proofs::arithmetic::Field;
 use pasta_curves::{group::Curve, pallas};
 use rand::{CryptoRng, RngCore};
 use taiga_halo2::{
-    nullifier::NullifierKey,
+    nullifier::NullifierKeyContainer,
     transaction::{ShieldedPartialTxBundle, Transaction},
 };
 
@@ -19,7 +19,7 @@ pub fn create_token_swap_transaction<R: RngCore + CryptoRng>(mut rng: R) -> Tran
     // Alice creates the partial transaction
     let alice_auth_sk = pallas::Scalar::random(&mut rng);
     let alice_auth_pk = generator * alice_auth_sk;
-    let alice_nk = NullifierKey::random(&mut rng);
+    let alice_nk = NullifierKeyContainer::random_key(&mut rng);
 
     let (alice_ptx, alice_r) = create_token_swap_ptx(
         &mut rng,
@@ -30,13 +30,13 @@ pub fn create_token_swap_transaction<R: RngCore + CryptoRng>(mut rng: R) -> Tran
         "eth",
         10,
         alice_auth_pk,
-        alice_nk,
+        alice_nk.to_commitment(),
     );
 
     // Bob creates the partial transaction
     let bob_auth_sk = pallas::Scalar::random(&mut rng);
     let bob_auth_pk = generator * bob_auth_sk;
-    let bob_nk = NullifierKey::random(&mut rng);
+    let bob_nk = NullifierKeyContainer::random_key(&mut rng);
 
     let (bob_ptx, bob_r) = create_token_swap_ptx(
         &mut rng,
@@ -47,13 +47,13 @@ pub fn create_token_swap_transaction<R: RngCore + CryptoRng>(mut rng: R) -> Tran
         "xan",
         15,
         bob_auth_pk,
-        bob_nk,
+        bob_nk.to_commitment(),
     );
 
     // Carol creates the partial transaction
     let carol_auth_sk = pallas::Scalar::random(&mut rng);
     let carol_auth_pk = generator * carol_auth_sk;
-    let carol_nk = NullifierKey::random(&mut rng);
+    let carol_nk = NullifierKeyContainer::random_key(&mut rng);
 
     let (carol_ptx, carol_r) = create_token_swap_ptx(
         &mut rng,
@@ -64,7 +64,7 @@ pub fn create_token_swap_transaction<R: RngCore + CryptoRng>(mut rng: R) -> Tran
         "btc",
         5,
         carol_auth_pk,
-        carol_nk,
+        carol_nk.to_commitment(),
     );
 
     // Solver creates the final transaction

--- a/taiga_halo2/examples/tx_examples/token_swap_without_intent.rs
+++ b/taiga_halo2/examples/tx_examples/token_swap_without_intent.rs
@@ -9,7 +9,7 @@ use halo2_proofs::arithmetic::Field;
 use pasta_curves::{group::Curve, pallas};
 use rand::{CryptoRng, RngCore};
 use taiga_halo2::{
-    nullifier::NullifierKeyCom,
+    nullifier::NullifierKey,
     transaction::{ShieldedPartialTxBundle, Transaction},
 };
 
@@ -19,8 +19,7 @@ pub fn create_token_swap_transaction<R: RngCore + CryptoRng>(mut rng: R) -> Tran
     // Alice creates the partial transaction
     let alice_auth_sk = pallas::Scalar::random(&mut rng);
     let alice_auth_pk = generator * alice_auth_sk;
-    let alice_nk_com = NullifierKeyCom::rand(&mut rng);
-    let alice_nk = alice_nk_com.get_nk().unwrap();
+    let alice_nk = NullifierKey::random(&mut rng);
 
     let (alice_ptx, alice_r) = create_token_swap_ptx(
         &mut rng,
@@ -31,14 +30,13 @@ pub fn create_token_swap_transaction<R: RngCore + CryptoRng>(mut rng: R) -> Tran
         "eth",
         10,
         alice_auth_pk,
-        alice_nk_com.get_nk_com(),
+        alice_nk,
     );
 
     // Bob creates the partial transaction
     let bob_auth_sk = pallas::Scalar::random(&mut rng);
     let bob_auth_pk = generator * bob_auth_sk;
-    let bob_nk_com = NullifierKeyCom::rand(&mut rng);
-    let bob_nk = bob_nk_com.get_nk().unwrap();
+    let bob_nk = NullifierKey::random(&mut rng);
 
     let (bob_ptx, bob_r) = create_token_swap_ptx(
         &mut rng,
@@ -49,14 +47,13 @@ pub fn create_token_swap_transaction<R: RngCore + CryptoRng>(mut rng: R) -> Tran
         "xan",
         15,
         bob_auth_pk,
-        bob_nk_com.get_nk_com(),
+        bob_nk,
     );
 
     // Carol creates the partial transaction
     let carol_auth_sk = pallas::Scalar::random(&mut rng);
     let carol_auth_pk = generator * carol_auth_sk;
-    let carol_nk_com = NullifierKeyCom::rand(&mut rng);
-    let carol_nk = carol_nk_com.get_nk().unwrap();
+    let carol_nk = NullifierKey::random(&mut rng);
 
     let (carol_ptx, carol_r) = create_token_swap_ptx(
         &mut rng,
@@ -67,7 +64,7 @@ pub fn create_token_swap_transaction<R: RngCore + CryptoRng>(mut rng: R) -> Tran
         "btc",
         5,
         carol_auth_pk,
-        carol_nk_com.get_nk_com(),
+        carol_nk,
     );
 
     // Solver creates the final transaction

--- a/taiga_halo2/src/circuit/integrity.rs
+++ b/taiga_halo2/src/circuit/integrity.rs
@@ -94,7 +94,7 @@ pub fn check_input_note(
 ) -> Result<InputNoteVariables, Error> {
     // Check input note user integrity: address = Com_r(Com_r(nk, zero), app_data_dynamic)
     // Witness nk
-    let nk = input_note.get_nk().get_open_nk().unwrap();
+    let nk = input_note.get_nk().unwrap();
     let nk_var = assign_free_advice(
         layouter.namespace(|| "witness nk"),
         advices[0],
@@ -254,7 +254,7 @@ pub fn check_output_note(
     let nk_com = assign_free_advice(
         layouter.namespace(|| "witness nk_com"),
         advices[0],
-        Value::known(output_note.get_nk().get_closed_nk()),
+        Value::known(output_note.get_nk_commitment()),
     )?;
 
     // Witness app_data_dynamic
@@ -479,7 +479,7 @@ fn test_halo2_nullifier_circuit() {
     use crate::circuit::gadgets::assign_free_advice;
     use crate::constant::{NoteCommitmentDomain, NoteCommitmentHashDomain, TaigaFixedBases};
     use crate::note::NoteCommitment;
-    use crate::nullifier::{Nullifier, NullifierKey};
+    use crate::nullifier::{Nullifier, NullifierKeyContainer};
     use halo2_gadgets::{
         ecc::chip::EccConfig,
         poseidon::{
@@ -498,7 +498,7 @@ fn test_halo2_nullifier_circuit() {
 
     #[derive(Default)]
     struct MyCircuit {
-        nk: NullifierKey,
+        nk: NullifierKeyContainer,
         rho: pallas::Base,
         psi: pallas::Base,
         cm: NoteCommitment,
@@ -612,7 +612,7 @@ fn test_halo2_nullifier_circuit() {
             let nk = assign_free_advice(
                 layouter.namespace(|| "witness nk"),
                 advices[0],
-                Value::known(self.nk.get_open_nk().unwrap()),
+                Value::known(self.nk.get_nk().unwrap()),
             )?;
 
             // Witness rho
@@ -667,7 +667,7 @@ fn test_halo2_nullifier_circuit() {
 
     let mut rng = OsRng;
     let circuit = MyCircuit {
-        nk: NullifierKey::random(&mut rng),
+        nk: NullifierKeyContainer::random_key(&mut rng),
         rho: pallas::Base::random(&mut rng),
         psi: pallas::Base::random(&mut rng),
         cm: NoteCommitment::default(),

--- a/taiga_halo2/src/circuit/note_circuit.rs
+++ b/taiga_halo2/src/circuit/note_circuit.rs
@@ -705,7 +705,7 @@ impl NoteChip {
 fn test_halo2_note_commitment_circuit() {
     use crate::circuit::gadgets::assign_free_advice;
     use crate::note::{Note, RandomSeed};
-    use crate::nullifier::{Nullifier, NullifierKeyCom};
+    use crate::nullifier::{Nullifier, NullifierKey};
     use halo2_gadgets::{
         ecc::{
             chip::{EccChip, EccConfig},
@@ -729,7 +729,7 @@ fn test_halo2_note_commitment_circuit() {
         app_data_static: pallas::Base,
         app_data_dynamic: pallas::Base,
         value: u64,
-        nk_com: NullifierKeyCom,
+        nk: NullifierKey,
         rho: Nullifier,
         is_merkle_checked: bool,
         rseed: RandomSeed,
@@ -822,7 +822,7 @@ fn test_halo2_note_commitment_circuit() {
                 self.app_data_static,
                 self.app_data_dynamic,
                 self.value,
-                self.nk_com,
+                self.nk,
                 self.rho,
                 self.is_merkle_checked,
                 self.rseed,
@@ -929,7 +929,7 @@ fn test_halo2_note_commitment_circuit() {
             app_data_static: pallas::Base::random(&mut rng),
             app_data_dynamic: pallas::Base::random(&mut rng),
             value: rng.next_u64(),
-            nk_com: NullifierKeyCom::rand(&mut rng),
+            nk: NullifierKey::random(&mut rng),
             rho: Nullifier::default(),
             is_merkle_checked: false,
             rseed: RandomSeed::random(&mut rng),
@@ -946,7 +946,7 @@ fn test_halo2_note_commitment_circuit() {
             app_data_static: pallas::Base::random(&mut rng),
             app_data_dynamic: pallas::Base::random(&mut rng),
             value: rng.next_u64(),
-            nk_com: NullifierKeyCom::rand(&mut rng),
+            nk: NullifierKey::random(&mut rng),
             rho: Nullifier::default(),
             is_merkle_checked: true,
             rseed: RandomSeed::random(&mut rng),

--- a/taiga_halo2/src/circuit/note_circuit.rs
+++ b/taiga_halo2/src/circuit/note_circuit.rs
@@ -705,7 +705,7 @@ impl NoteChip {
 fn test_halo2_note_commitment_circuit() {
     use crate::circuit::gadgets::assign_free_advice;
     use crate::note::{Note, RandomSeed};
-    use crate::nullifier::{Nullifier, NullifierKey};
+    use crate::nullifier::{Nullifier, NullifierKeyContainer};
     use halo2_gadgets::{
         ecc::{
             chip::{EccChip, EccConfig},
@@ -729,7 +729,7 @@ fn test_halo2_note_commitment_circuit() {
         app_data_static: pallas::Base,
         app_data_dynamic: pallas::Base,
         value: u64,
-        nk: NullifierKey,
+        nk: NullifierKeyContainer,
         rho: Nullifier,
         is_merkle_checked: bool,
         rseed: RandomSeed,
@@ -929,7 +929,7 @@ fn test_halo2_note_commitment_circuit() {
             app_data_static: pallas::Base::random(&mut rng),
             app_data_dynamic: pallas::Base::random(&mut rng),
             value: rng.next_u64(),
-            nk: NullifierKey::random(&mut rng),
+            nk: NullifierKeyContainer::random_key(&mut rng),
             rho: Nullifier::default(),
             is_merkle_checked: false,
             rseed: RandomSeed::random(&mut rng),
@@ -946,7 +946,7 @@ fn test_halo2_note_commitment_circuit() {
             app_data_static: pallas::Base::random(&mut rng),
             app_data_dynamic: pallas::Base::random(&mut rng),
             value: rng.next_u64(),
-            nk: NullifierKey::random(&mut rng),
+            nk: NullifierKeyContainer::random_key(&mut rng),
             rho: Nullifier::default(),
             is_merkle_checked: true,
             rseed: RandomSeed::random(&mut rng),

--- a/taiga_halo2/src/circuit/vp_examples/cascade_intent.rs
+++ b/taiga_halo2/src/circuit/vp_examples/cascade_intent.rs
@@ -18,7 +18,7 @@ use crate::{
     },
     constant::{NUM_NOTE, SETUP_PARAMS_MAP},
     note::{Note, RandomSeed},
-    nullifier::{Nullifier, NullifierKeyCom},
+    nullifier::{Nullifier, NullifierKey},
     proof::Proof,
     vp_vk::ValidityPredicateVerifyingKey,
 };
@@ -60,8 +60,8 @@ impl CascadeIntentValidityPredicateCircuit {
         let cascade_input_note = Note::dummy(&mut rng);
         let cascade_note_cm = cascade_input_note.commitment().get_x();
         let rho = Nullifier::new(pallas::Base::random(&mut rng));
-        let nk_com = NullifierKeyCom::rand(&mut rng);
-        let intent_note = create_intent_note(&mut rng, cascade_note_cm, rho, nk_com);
+        let nk = NullifierKey::random(&mut rng);
+        let intent_note = create_intent_note(&mut rng, cascade_note_cm, rho, nk);
         let input_notes = [intent_note, cascade_input_note];
         Self {
             owned_note_pub_id: input_notes[0].get_nf().unwrap().inner(),
@@ -153,7 +153,7 @@ pub fn create_intent_note<R: RngCore>(
     mut rng: R,
     cascade_note_cm: pallas::Base,
     rho: Nullifier,
-    nk_com: NullifierKeyCom,
+    nk: NullifierKey,
 ) -> Note {
     let app_data_static =
         CascadeIntentValidityPredicateCircuit::encode_app_data_static(cascade_note_cm);
@@ -163,7 +163,7 @@ pub fn create_intent_note<R: RngCore>(
         app_data_static,
         pallas::Base::zero(),
         1u64,
-        nk_com,
+        nk,
         rho,
         false,
         rseed,

--- a/taiga_halo2/src/circuit/vp_examples/cascade_intent.rs
+++ b/taiga_halo2/src/circuit/vp_examples/cascade_intent.rs
@@ -18,7 +18,7 @@ use crate::{
     },
     constant::{NUM_NOTE, SETUP_PARAMS_MAP},
     note::{Note, RandomSeed},
-    nullifier::{Nullifier, NullifierKey},
+    nullifier::{Nullifier, NullifierKeyContainer},
     proof::Proof,
     vp_vk::ValidityPredicateVerifyingKey,
 };
@@ -60,7 +60,7 @@ impl CascadeIntentValidityPredicateCircuit {
         let cascade_input_note = Note::dummy(&mut rng);
         let cascade_note_cm = cascade_input_note.commitment().get_x();
         let rho = Nullifier::new(pallas::Base::random(&mut rng));
-        let nk = NullifierKey::random(&mut rng);
+        let nk = NullifierKeyContainer::random_key(&mut rng);
         let intent_note = create_intent_note(&mut rng, cascade_note_cm, rho, nk);
         let input_notes = [intent_note, cascade_input_note];
         Self {
@@ -153,7 +153,7 @@ pub fn create_intent_note<R: RngCore>(
     mut rng: R,
     cascade_note_cm: pallas::Base,
     rho: Nullifier,
-    nk: NullifierKey,
+    nk: NullifierKeyContainer,
 ) -> Note {
     let app_data_static =
         CascadeIntentValidityPredicateCircuit::encode_app_data_static(cascade_note_cm);

--- a/taiga_halo2/src/circuit/vp_examples/or_relation_intent.rs
+++ b/taiga_halo2/src/circuit/vp_examples/or_relation_intent.rs
@@ -20,7 +20,7 @@ use crate::{
     },
     constant::{NUM_NOTE, SETUP_PARAMS_MAP},
     note::{Note, RandomSeed},
-    nullifier::{Nullifier, NullifierKeyCom},
+    nullifier::{Nullifier, NullifierKey},
     proof::Proof,
     utils::poseidon_hash_n,
     vp_vk::ValidityPredicateVerifyingKey,
@@ -100,14 +100,14 @@ impl OrRelationIntentValidityPredicateCircuit {
         let receiver_address = output_notes[0].get_address();
 
         let rho = Nullifier::new(pallas::Base::random(&mut rng));
-        let nk_com = NullifierKeyCom::rand(&mut rng);
+        let nk = NullifierKey::random(&mut rng);
         let intent_note = create_intent_note(
             &mut rng,
             &condition1,
             &condition2,
             receiver_address,
             rho,
-            nk_com,
+            nk,
         );
         let padding_input_note = Note::dummy(&mut rng);
         let input_notes = [intent_note, padding_input_note];
@@ -301,7 +301,7 @@ pub fn create_intent_note<R: RngCore>(
     condition2: &Condition,
     receiver_address: pallas::Base,
     rho: Nullifier,
-    nk_com: NullifierKeyCom,
+    nk: NullifierKey,
 ) -> Note {
     let app_data_static = OrRelationIntentValidityPredicateCircuit::encode_app_data_static(
         condition1,
@@ -314,7 +314,7 @@ pub fn create_intent_note<R: RngCore>(
         app_data_static,
         pallas::Base::zero(),
         1u64,
-        nk_com,
+        nk,
         rho,
         false,
         rseed,

--- a/taiga_halo2/src/circuit/vp_examples/or_relation_intent.rs
+++ b/taiga_halo2/src/circuit/vp_examples/or_relation_intent.rs
@@ -20,7 +20,7 @@ use crate::{
     },
     constant::{NUM_NOTE, SETUP_PARAMS_MAP},
     note::{Note, RandomSeed},
-    nullifier::{Nullifier, NullifierKey},
+    nullifier::{Nullifier, NullifierKeyContainer},
     proof::Proof,
     utils::poseidon_hash_n,
     vp_vk::ValidityPredicateVerifyingKey,
@@ -100,7 +100,7 @@ impl OrRelationIntentValidityPredicateCircuit {
         let receiver_address = output_notes[0].get_address();
 
         let rho = Nullifier::new(pallas::Base::random(&mut rng));
-        let nk = NullifierKey::random(&mut rng);
+        let nk = NullifierKeyContainer::random_key(&mut rng);
         let intent_note = create_intent_note(
             &mut rng,
             &condition1,
@@ -301,7 +301,7 @@ pub fn create_intent_note<R: RngCore>(
     condition2: &Condition,
     receiver_address: pallas::Base,
     rho: Nullifier,
-    nk: NullifierKey,
+    nk: NullifierKeyContainer,
 ) -> Note {
     let app_data_static = OrRelationIntentValidityPredicateCircuit::encode_app_data_static(
         condition1,

--- a/taiga_halo2/src/circuit/vp_examples/partial_fulfillment_intent.rs
+++ b/taiga_halo2/src/circuit/vp_examples/partial_fulfillment_intent.rs
@@ -22,7 +22,7 @@ use crate::{
     },
     constant::{NUM_NOTE, SETUP_PARAMS_MAP},
     note::{Note, RandomSeed},
-    nullifier::{Nullifier, NullifierKeyCom},
+    nullifier::{Nullifier, NullifierKey},
     proof::Proof,
     utils::poseidon_hash_n,
     vp_vk::ValidityPredicateVerifyingKey,
@@ -96,8 +96,8 @@ impl PartialFulfillmentIntentValidityPredicateCircuit {
         let receiver_address = output_notes[0].get_address();
 
         let rho = Nullifier::new(pallas::Base::random(&mut rng));
-        let nk_com = NullifierKeyCom::rand(&mut rng);
-        let intent_note = create_intent_note(&mut rng, &sell, &buy, receiver_address, rho, nk_com);
+        let nk = NullifierKey::random(&mut rng);
+        let intent_note = create_intent_note(&mut rng, &sell, &buy, receiver_address, rho, nk);
         let padding_input_note = Note::dummy(&mut rng);
         let input_notes = [intent_note, padding_input_note];
         Self {
@@ -447,7 +447,7 @@ pub fn create_intent_note<R: RngCore>(
     buy: &Token,
     receiver_address: pallas::Base,
     rho: Nullifier,
-    nk_com: NullifierKeyCom,
+    nk: NullifierKey,
 ) -> Note {
     let app_data_static = PartialFulfillmentIntentValidityPredicateCircuit::encode_app_data_static(
         sell,
@@ -460,7 +460,7 @@ pub fn create_intent_note<R: RngCore>(
         app_data_static,
         pallas::Base::zero(),
         1u64,
-        nk_com,
+        nk,
         rho,
         false,
         rseed,
@@ -490,8 +490,8 @@ fn test_halo2_partial_fulfillment_intent_vp_circuit() {
     sold_note.value = sell.value;
     let receiver_address = sold_note.get_address();
     let rho = Nullifier::new(pallas::Base::random(&mut rng));
-    let nk_com = NullifierKeyCom::rand(&mut rng);
-    let intent_note = create_intent_note(&mut rng, &sell, &buy, receiver_address, rho, nk_com);
+    let nk = NullifierKey::random(&mut rng);
+    let intent_note = create_intent_note(&mut rng, &sell, &buy, receiver_address, rho, nk);
     // Creating intent test
     {
         let input_notes = [sold_note, dummy_note];
@@ -519,7 +519,7 @@ fn test_halo2_partial_fulfillment_intent_vp_circuit() {
             bought_note.note_type.app_data_static =
                 transfrom_token_name_to_token_property(&buy.name);
             bought_note.app_data_dynamic = sold_note.app_data_dynamic;
-            bought_note.nk_com = sold_note.nk_com;
+            bought_note.nk = sold_note.nk;
 
             // full fulfillment
             {

--- a/taiga_halo2/src/circuit/vp_examples/partial_fulfillment_intent.rs
+++ b/taiga_halo2/src/circuit/vp_examples/partial_fulfillment_intent.rs
@@ -22,7 +22,7 @@ use crate::{
     },
     constant::{NUM_NOTE, SETUP_PARAMS_MAP},
     note::{Note, RandomSeed},
-    nullifier::{Nullifier, NullifierKey},
+    nullifier::{Nullifier, NullifierKeyContainer},
     proof::Proof,
     utils::poseidon_hash_n,
     vp_vk::ValidityPredicateVerifyingKey,
@@ -96,7 +96,7 @@ impl PartialFulfillmentIntentValidityPredicateCircuit {
         let receiver_address = output_notes[0].get_address();
 
         let rho = Nullifier::new(pallas::Base::random(&mut rng));
-        let nk = NullifierKey::random(&mut rng);
+        let nk = NullifierKeyContainer::random_key(&mut rng);
         let intent_note = create_intent_note(&mut rng, &sell, &buy, receiver_address, rho, nk);
         let padding_input_note = Note::dummy(&mut rng);
         let input_notes = [intent_note, padding_input_note];
@@ -447,7 +447,7 @@ pub fn create_intent_note<R: RngCore>(
     buy: &Token,
     receiver_address: pallas::Base,
     rho: Nullifier,
-    nk: NullifierKey,
+    nk: NullifierKeyContainer,
 ) -> Note {
     let app_data_static = PartialFulfillmentIntentValidityPredicateCircuit::encode_app_data_static(
         sell,
@@ -490,7 +490,7 @@ fn test_halo2_partial_fulfillment_intent_vp_circuit() {
     sold_note.value = sell.value;
     let receiver_address = sold_note.get_address();
     let rho = Nullifier::new(pallas::Base::random(&mut rng));
-    let nk = NullifierKey::random(&mut rng);
+    let nk = NullifierKeyContainer::random_key(&mut rng);
     let intent_note = create_intent_note(&mut rng, &sell, &buy, receiver_address, rho, nk);
     // Creating intent test
     {
@@ -519,7 +519,7 @@ fn test_halo2_partial_fulfillment_intent_vp_circuit() {
             bought_note.note_type.app_data_static =
                 transfrom_token_name_to_token_property(&buy.name);
             bought_note.app_data_dynamic = sold_note.app_data_dynamic;
-            bought_note.nk = sold_note.nk;
+            bought_note.nk_container = sold_note.nk_container;
 
             // full fulfillment
             {

--- a/taiga_halo2/src/circuit/vp_examples/receiver_vp.rs
+++ b/taiga_halo2/src/circuit/vp_examples/receiver_vp.rs
@@ -15,7 +15,7 @@ use crate::{
     constant::{GENERATOR, NUM_NOTE, SETUP_PARAMS_MAP, VP_CIRCUIT_CUSTOM_INSTANCE_BEGIN_IDX},
     note::Note,
     note_encryption::{NoteCipher, SecretKey},
-    nullifier::{Nullifier, NullifierKey},
+    nullifier::{Nullifier, NullifierKeyContainer},
     proof::Proof,
     utils::{mod_r_p, poseidon_hash_n},
     vp_vk::ValidityPredicateVerifyingKey,
@@ -130,7 +130,7 @@ impl ValidityPredicateInfo for ReceiverValidityPredicateCircuit {
             target_note.app_data_dynamic,
             pallas::Base::from(target_note.value),
             target_note.rho.inner(),
-            target_note.get_nk().get_closed_nk(),
+            target_note.get_nk_commitment(),
             target_note.psi,
             target_note.rcm,
         ];
@@ -358,7 +358,7 @@ pub fn decrypt_note(instances: Vec<pallas::Base>, sk: pallas::Base) -> Option<No
                     .expect("slice with incorrect length"),
             );
             let rho = Nullifier::new(plaintext[4]);
-            let nk = NullifierKey::from_closed(plaintext[5]);
+            let nk = NullifierKeyContainer::from_commitment(plaintext[5]);
             let note = Note::from_full(
                 plaintext[0],
                 plaintext[1],

--- a/taiga_halo2/src/circuit/vp_examples/receiver_vp.rs
+++ b/taiga_halo2/src/circuit/vp_examples/receiver_vp.rs
@@ -15,7 +15,7 @@ use crate::{
     constant::{GENERATOR, NUM_NOTE, SETUP_PARAMS_MAP, VP_CIRCUIT_CUSTOM_INSTANCE_BEGIN_IDX},
     note::Note,
     note_encryption::{NoteCipher, SecretKey},
-    nullifier::{Nullifier, NullifierKeyCom},
+    nullifier::{Nullifier, NullifierKey},
     proof::Proof,
     utils::{mod_r_p, poseidon_hash_n},
     vp_vk::ValidityPredicateVerifyingKey,
@@ -130,7 +130,7 @@ impl ValidityPredicateInfo for ReceiverValidityPredicateCircuit {
             target_note.app_data_dynamic,
             pallas::Base::from(target_note.value),
             target_note.rho.inner(),
-            target_note.nk_com.get_nk_com(),
+            target_note.get_nk().get_closed_nk(),
             target_note.psi,
             target_note.rcm,
         ];
@@ -358,13 +358,13 @@ pub fn decrypt_note(instances: Vec<pallas::Base>, sk: pallas::Base) -> Option<No
                     .expect("slice with incorrect length"),
             );
             let rho = Nullifier::new(plaintext[4]);
-            let nk_com = NullifierKeyCom::from_closed(plaintext[5]);
+            let nk = NullifierKey::from_closed(plaintext[5]);
             let note = Note::from_full(
                 plaintext[0],
                 plaintext[1],
                 plaintext[2],
                 value,
-                nk_com,
+                nk,
                 rho,
                 true,
                 plaintext[6],

--- a/taiga_halo2/src/note.rs
+++ b/taiga_halo2/src/note.rs
@@ -8,7 +8,7 @@ use crate::{
         PRF_EXPAND_PERSONALIZATION, PRF_EXPAND_PSI, PRF_EXPAND_RCM, TAIGA_COMMITMENT_TREE_DEPTH,
     },
     merkle_tree::{MerklePath, Node, LR},
-    nullifier::{Nullifier, NullifierKey},
+    nullifier::{Nullifier, NullifierKeyContainer},
     utils::{extract_p, mod_r_p, poseidon_hash, poseidon_to_curve},
 };
 use bitvec::{array::BitArray, order::Lsb0};
@@ -58,8 +58,8 @@ pub struct Note {
     pub app_data_dynamic: pallas::Base,
     /// value denotes the amount of the note.
     pub value: u64,
-    /// the wrapped nullifier key.
-    pub nk: NullifierKey,
+    /// NullifierKeyContainer contains the nullifier_key or the nullifier_key commitment.
+    pub nk_container: NullifierKeyContainer,
     /// old nullifier. Nonce which is a deterministically computed, unique nonce
     pub rho: Nullifier,
     /// psi is to derive the nullifier
@@ -105,7 +105,7 @@ impl Note {
         app_data_static: pallas::Base,
         app_data_dynamic: pallas::Base,
         value: u64,
-        nk: NullifierKey,
+        nk_container: NullifierKeyContainer,
         rho: Nullifier,
         is_merkle_checked: bool,
         rseed: RandomSeed,
@@ -115,7 +115,7 @@ impl Note {
             note_type,
             app_data_dynamic,
             value,
-            nk,
+            nk_container,
             is_merkle_checked,
             psi: rseed.get_psi(&rho),
             rcm: rseed.get_rcm(&rho),
@@ -129,7 +129,7 @@ impl Note {
         app_data_static: pallas::Base,
         app_data_dynamic: pallas::Base,
         value: u64,
-        nk: NullifierKey,
+        nk_container: NullifierKeyContainer,
         rho: Nullifier,
         is_merkle_checked: bool,
         psi: pallas::Base,
@@ -140,7 +140,7 @@ impl Note {
             note_type,
             app_data_dynamic,
             value,
-            nk,
+            nk_container,
             is_merkle_checked,
             psi,
             rcm,
@@ -155,16 +155,20 @@ impl Note {
 
     pub fn dummy_input<R: RngCore>(mut rng: R) -> Self {
         let rho = Nullifier::new(pallas::Base::random(&mut rng));
-        let nk = NullifierKey::from_open(pallas::Base::random(&mut rng));
+        let nk = NullifierKeyContainer::from_key(pallas::Base::random(&mut rng));
         Self::dummy_from_parts(rng, rho, nk)
     }
 
     pub fn dummy_output<R: RngCore>(mut rng: R, rho: Nullifier) -> Self {
-        let nk = NullifierKey::from_closed(pallas::Base::random(&mut rng));
-        Self::dummy_from_parts(rng, rho, nk)
+        let nk_com = NullifierKeyContainer::from_commitment(pallas::Base::random(&mut rng));
+        Self::dummy_from_parts(rng, rho, nk_com)
     }
 
-    pub fn dummy_from_parts<R: RngCore>(mut rng: R, rho: Nullifier, nk: NullifierKey) -> Self {
+    pub fn dummy_from_parts<R: RngCore>(
+        mut rng: R,
+        rho: Nullifier,
+        nk_container: NullifierKeyContainer,
+    ) -> Self {
         let app_vk = pallas::Base::random(&mut rng);
         let app_data_static = pallas::Base::random(&mut rng);
         let note_type = ValueBase::new(app_vk, app_data_static);
@@ -175,7 +179,7 @@ impl Note {
             note_type,
             app_data_dynamic,
             value,
-            nk,
+            nk_container,
             is_merkle_checked: true,
             psi: rseed.get_psi(&rho),
             rcm: rseed.get_rcm(&rho),
@@ -188,13 +192,13 @@ impl Note {
         let app_data_static = pallas::Base::random(&mut rng);
         let note_type = ValueBase::new(app_vk, app_data_static);
         let app_data_dynamic = pallas::Base::zero();
-        let nk = NullifierKey::random(&mut rng);
+        let nk = NullifierKeyContainer::random_key(&mut rng);
         let rseed = RandomSeed::random(&mut rng);
         Self {
             note_type,
             app_data_dynamic,
             value: 0,
-            nk,
+            nk_container: nk,
             rho,
             psi: rseed.get_psi(&rho),
             rcm: rseed.get_rcm(&rho),
@@ -252,7 +256,7 @@ impl Note {
 
     pub fn get_nf(&self) -> Option<Nullifier> {
         Nullifier::derive(
-            &self.get_nk(),
+            &self.nk_container,
             &self.rho.inner(),
             &self.psi,
             &self.commitment(),
@@ -260,11 +264,15 @@ impl Note {
     }
 
     pub fn get_address(&self) -> pallas::Base {
-        poseidon_hash(self.app_data_dynamic, self.nk.get_closed_nk())
+        poseidon_hash(self.app_data_dynamic, self.get_nk_commitment())
     }
 
-    pub fn get_nk(&self) -> NullifierKey {
-        self.nk
+    pub fn get_nk(&self) -> Option<pallas::Base> {
+        self.nk_container.get_nk()
+    }
+
+    pub fn get_nk_commitment(&self) -> pallas::Base {
+        self.nk_container.get_commitment()
     }
 
     pub fn get_value_base(&self) -> pallas::Point {
@@ -298,13 +306,13 @@ impl BorshSerialize for Note {
         writer.write_all(&self.app_data_dynamic.to_repr())?;
         // Write note value
         writer.write_u64::<LittleEndian>(self.value)?;
-        // Write nk
-        match self.nk {
-            NullifierKey::Closed(nk) => {
+        // Write nk_container
+        match self.nk_container {
+            NullifierKeyContainer::Commitment(nk) => {
                 writer.write_u8(1)?;
                 writer.write_all(&nk.to_repr())
             }
-            NullifierKey::Open(nk) => {
+            NullifierKeyContainer::Key(nk) => {
                 writer.write_u8(2)?;
                 writer.write_all(&nk.to_repr())
             }
@@ -342,15 +350,15 @@ impl BorshDeserialize for Note {
             })?;
         // Read note value
         let value = buf.read_u64::<LittleEndian>()?;
-        // Read nk
-        let nk_type = buf.read_u8()?;
-        let nk_bytes = <[u8; 32]>::deserialize(buf)?;
-        let nk = Option::from(pallas::Base::from_repr(nk_bytes))
+        // Read nk_container
+        let nk_container_type = buf.read_u8()?;
+        let nk_container_bytes = <[u8; 32]>::deserialize(buf)?;
+        let nk = Option::from(pallas::Base::from_repr(nk_container_bytes))
             .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "nk not in field"))?;
-        let nk = if nk_type == 0x01 {
-            NullifierKey::from_closed(nk)
+        let nk_container = if nk_container_type == 0x01 {
+            NullifierKeyContainer::from_commitment(nk)
         } else {
-            NullifierKey::from_open(nk)
+            NullifierKeyContainer::from_key(nk)
         };
         // Read rho
         let rho_bytes = <[u8; 32]>::deserialize(buf)?;
@@ -373,7 +381,7 @@ impl BorshDeserialize for Note {
             app_data_static,
             app_data_dynamic,
             value,
-            nk,
+            nk_container,
             rho,
             is_merkle_checked,
             psi,

--- a/taiga_halo2/src/shielded_ptx.rs
+++ b/taiga_halo2/src/shielded_ptx.rs
@@ -332,7 +332,7 @@ pub mod testing {
         constant::TAIGA_COMMITMENT_TREE_DEPTH,
         merkle_tree::MerklePath,
         note::{InputNoteProvingInfo, Note, OutputNoteProvingInfo, RandomSeed},
-        nullifier::{Nullifier, NullifierKeyCom},
+        nullifier::{Nullifier, NullifierKey},
         shielded_ptx::ShieldedPartialTransaction,
         utils::poseidon_hash,
     };
@@ -359,7 +359,7 @@ pub mod testing {
             let app_data_dynamic = poseidon_hash(app_dynamic_vp_vk[0], app_dynamic_vp_vk[1]);
             let rho = Nullifier::new(pallas::Base::random(&mut rng));
             let value = 5000u64;
-            let nk_com = NullifierKeyCom::rand(&mut rng);
+            let nk = NullifierKey::random(&mut rng);
             let rseed = RandomSeed::random(&mut rng);
             let is_merkle_checked = true;
             Note::new(
@@ -367,7 +367,7 @@ pub mod testing {
                 app_data_static,
                 app_data_dynamic,
                 value,
-                nk_com,
+                nk,
                 rho,
                 is_merkle_checked,
                 rseed,
@@ -380,7 +380,7 @@ pub mod testing {
             let app_data_dynamic = pallas::Base::zero();
             let rho = input_note_1.get_nf().unwrap();
             let value = 5000u64;
-            let nk_com = NullifierKeyCom::rand(&mut rng);
+            let nk = NullifierKey::random(&mut rng);
             let rseed = RandomSeed::random(&mut rng);
             let is_merkle_checked = true;
             Note::new(
@@ -388,7 +388,7 @@ pub mod testing {
                 app_data_static,
                 app_data_dynamic,
                 value,
-                nk_com,
+                nk,
                 rho,
                 is_merkle_checked,
                 rseed,
@@ -400,7 +400,7 @@ pub mod testing {
             let app_data_dynamic = pallas::Base::zero();
             let rho = Nullifier::new(pallas::Base::random(&mut rng));
             let value = 10u64;
-            let nk_com = NullifierKeyCom::rand(&mut rng);
+            let nk = NullifierKey::random(&mut rng);
             let rseed = RandomSeed::random(&mut rng);
             let is_merkle_checked = true;
             Note::new(
@@ -408,7 +408,7 @@ pub mod testing {
                 app_data_static,
                 app_data_dynamic,
                 value,
-                nk_com,
+                nk,
                 rho,
                 is_merkle_checked,
                 rseed,
@@ -419,7 +419,7 @@ pub mod testing {
             let app_data_dynamic = pallas::Base::zero();
             let rho = input_note_2.get_nf().unwrap();
             let value = 10u64;
-            let nk_com = NullifierKeyCom::rand(&mut rng);
+            let nk = NullifierKey::random(&mut rng);
             let rseed = RandomSeed::random(&mut rng);
             let is_merkle_checked = true;
             Note::new(
@@ -427,7 +427,7 @@ pub mod testing {
                 app_data_static,
                 app_data_dynamic,
                 value,
-                nk_com,
+                nk,
                 rho,
                 is_merkle_checked,
                 rseed,

--- a/taiga_halo2/src/shielded_ptx.rs
+++ b/taiga_halo2/src/shielded_ptx.rs
@@ -332,7 +332,7 @@ pub mod testing {
         constant::TAIGA_COMMITMENT_TREE_DEPTH,
         merkle_tree::MerklePath,
         note::{InputNoteProvingInfo, Note, OutputNoteProvingInfo, RandomSeed},
-        nullifier::{Nullifier, NullifierKey},
+        nullifier::{Nullifier, NullifierKeyContainer},
         shielded_ptx::ShieldedPartialTransaction,
         utils::poseidon_hash,
     };
@@ -359,7 +359,7 @@ pub mod testing {
             let app_data_dynamic = poseidon_hash(app_dynamic_vp_vk[0], app_dynamic_vp_vk[1]);
             let rho = Nullifier::new(pallas::Base::random(&mut rng));
             let value = 5000u64;
-            let nk = NullifierKey::random(&mut rng);
+            let nk = NullifierKeyContainer::random_key(&mut rng);
             let rseed = RandomSeed::random(&mut rng);
             let is_merkle_checked = true;
             Note::new(
@@ -380,7 +380,7 @@ pub mod testing {
             let app_data_dynamic = pallas::Base::zero();
             let rho = input_note_1.get_nf().unwrap();
             let value = 5000u64;
-            let nk = NullifierKey::random(&mut rng);
+            let nk_com = NullifierKeyContainer::random_commitment(&mut rng);
             let rseed = RandomSeed::random(&mut rng);
             let is_merkle_checked = true;
             Note::new(
@@ -388,7 +388,7 @@ pub mod testing {
                 app_data_static,
                 app_data_dynamic,
                 value,
-                nk,
+                nk_com,
                 rho,
                 is_merkle_checked,
                 rseed,
@@ -400,7 +400,7 @@ pub mod testing {
             let app_data_dynamic = pallas::Base::zero();
             let rho = Nullifier::new(pallas::Base::random(&mut rng));
             let value = 10u64;
-            let nk = NullifierKey::random(&mut rng);
+            let nk = NullifierKeyContainer::random_key(&mut rng);
             let rseed = RandomSeed::random(&mut rng);
             let is_merkle_checked = true;
             Note::new(
@@ -419,7 +419,7 @@ pub mod testing {
             let app_data_dynamic = pallas::Base::zero();
             let rho = input_note_2.get_nf().unwrap();
             let value = 10u64;
-            let nk = NullifierKey::random(&mut rng);
+            let nk_com = NullifierKeyContainer::random_commitment(&mut rng);
             let rseed = RandomSeed::random(&mut rng);
             let is_merkle_checked = true;
             Note::new(
@@ -427,7 +427,7 @@ pub mod testing {
                 app_data_static,
                 app_data_dynamic,
                 value,
-                nk,
+                nk_com,
                 rho,
                 is_merkle_checked,
                 rseed,


### PR DESCRIPTION
Merge `NullifierDerivingKey` and `NullifierKeyCom` into ~`NullifierKey`~ `NullifierKeyContainer`.
The `NullifierKeyContainer` contains the nullifier_key(`NullifierKeyContainer::Key`) or the nullifier_key commitment(`NullifierKeyContainer::Commitment`).
Rename the `nk_com` to `nk_container` in the `Note`.