### PR TITLE
refine the tests and adjust some basic structs and APIs

### DIFF
--- a/taiga_halo2/Cargo.toml
+++ b/taiga_halo2/Cargo.toml
@@ -26,9 +26,9 @@ num-bigint = "0.4.3"
 criterion = "0.3"
 proptest = "1.0.0"
 
-# [[bench]]
-# name = "action_proof"
-# harness = false
+[[bench]]
+name = "action_proof"
+harness = false
 
 [[bench]]
 name = "vp_proof"

--- a/taiga_halo2/Cargo.toml
+++ b/taiga_halo2/Cargo.toml
@@ -26,9 +26,9 @@ num-bigint = "0.4.3"
 criterion = "0.3"
 proptest = "1.0.0"
 
-[[bench]]
-name = "action_proof"
-harness = false
+# [[bench]]
+# name = "action_proof"
+# harness = false
 
 [[bench]]
 name = "vp_proof"

--- a/taiga_halo2/benches/vp_proof.rs
+++ b/taiga_halo2/benches/vp_proof.rs
@@ -1,16 +1,76 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use halo2_proofs::plonk::{keygen_pk, keygen_vk};
 
+use halo2_proofs::arithmetic::Field;
+use pasta_curves::pallas;
 use rand::rngs::OsRng;
-use taiga_halo2::circuit::vp_circuit::ValidityPredicateInfo;
-use taiga_halo2::circuit::vp_examples::TrivialValidityPredicateCircuit;
-use taiga_halo2::constant::SETUP_PARAMS_MAP;
-use taiga_halo2::proof::Proof;
+use rand::Rng;
+use taiga_halo2::{
+    circuit::{vp_circuit::ValidityPredicateInfo, vp_examples::TrivialValidityPredicateCircuit},
+    constant::{NUM_NOTE, SETUP_PARAMS_MAP},
+    note::{Note, NoteType, RandomSeed},
+    nullifier::{Nullifier, NullifierKeyContainer},
+    proof::Proof,
+};
 
 fn bench_vp_proof(name: &str, c: &mut Criterion) {
     let mut rng = OsRng;
 
-    let vp_circuit = TrivialValidityPredicateCircuit::dummy(&mut rng);
+    let vp_circuit = {
+        let input_notes = [(); NUM_NOTE].map(|_| {
+            let rho = Nullifier::new(pallas::Base::random(&mut rng));
+            let nk = NullifierKeyContainer::from_key(pallas::Base::random(&mut rng));
+            let note_type = {
+                let app_vk = pallas::Base::random(&mut rng);
+                let app_data_static = pallas::Base::random(&mut rng);
+                NoteType::new(app_vk, app_data_static)
+            };
+            let app_data_dynamic = pallas::Base::random(&mut rng);
+            let value: u64 = rng.gen();
+            let rseed = RandomSeed::random(&mut rng);
+            Note {
+                note_type,
+                app_data_dynamic,
+                value,
+                nk_container: nk,
+                is_merkle_checked: true,
+                psi: rseed.get_psi(&rho),
+                rcm: rseed.get_rcm(&rho),
+                rho,
+            }
+        });
+        let output_notes = input_notes
+            .iter()
+            .map(|input| {
+                let rho = input.get_nf().unwrap();
+                let nk_com = NullifierKeyContainer::from_commitment(pallas::Base::random(&mut rng));
+                let note_type = {
+                    let app_vk = pallas::Base::random(&mut rng);
+                    let app_data_static = pallas::Base::random(&mut rng);
+                    NoteType::new(app_vk, app_data_static)
+                };
+                let app_data_dynamic = pallas::Base::random(&mut rng);
+                let value: u64 = rng.gen();
+                let rseed = RandomSeed::random(&mut rng);
+                Note {
+                    note_type,
+                    app_data_dynamic,
+                    value,
+                    nk_container: nk_com,
+                    is_merkle_checked: true,
+                    psi: rseed.get_psi(&rho),
+                    rcm: rseed.get_rcm(&rho),
+                    rho,
+                }
+            })
+            .collect::<Vec<_>>();
+        let owned_note_pub_id = input_notes[0].get_nf().unwrap().inner();
+        TrivialValidityPredicateCircuit::new(
+            owned_note_pub_id,
+            input_notes,
+            output_notes.try_into().unwrap(),
+        )
+    };
     let params = SETUP_PARAMS_MAP.get(&12).unwrap();
     let empty_circuit: TrivialValidityPredicateCircuit = Default::default();
     let vk = keygen_vk(params, &empty_circuit).expect("keygen_vk should not fail");
@@ -21,7 +81,7 @@ fn bench_vp_proof(name: &str, c: &mut Criterion) {
     let prover_name = name.to_string() + "-prover";
     c.bench_function(&prover_name, |b| {
         b.iter(|| {
-            Proof::create(&pk, &params, vp_circuit.clone(), &[&instances], &mut rng);
+            Proof::create(&pk, &params, vp_circuit.clone(), &[&instances], &mut rng).unwrap();
         })
     });
 
@@ -32,7 +92,7 @@ fn bench_vp_proof(name: &str, c: &mut Criterion) {
     let verifier_name = name.to_string() + "-verifier";
     c.bench_function(&verifier_name, |b| {
         b.iter(|| {
-            proof.verify(pk.get_vk(), &params, &[&instances]).is_ok();
+            assert!(proof.verify(pk.get_vk(), &params, &[&instances]).is_ok());
         })
     });
 }

--- a/taiga_halo2/examples/taiga_sudoku/app_vp.rs
+++ b/taiga_halo2/examples/taiga_sudoku/app_vp.rs
@@ -584,11 +584,67 @@ impl ValidityPredicateCircuit for SudokuAppValidityPredicateCircuit {
 
 vp_circuit_impl!(SudokuAppValidityPredicateCircuit);
 
+#[cfg(test)]
+pub mod tests {
+    use halo2_proofs::arithmetic::Field;
+    use pasta_curves::pallas;
+    use rand::{Rng, RngCore};
+    use taiga_halo2::{
+        note::{Note, NoteType, RandomSeed},
+        nullifier::{Nullifier, NullifierKeyContainer},
+    };
+
+    pub fn random_input_note<R: RngCore>(mut rng: R) -> Note {
+        let rho = Nullifier::new(pallas::Base::random(&mut rng));
+        let nk = NullifierKeyContainer::from_key(pallas::Base::random(&mut rng));
+        let note_type = {
+            let app_vk = pallas::Base::random(&mut rng);
+            let app_data_static = pallas::Base::random(&mut rng);
+            NoteType::new(app_vk, app_data_static)
+        };
+        let app_data_dynamic = pallas::Base::random(&mut rng);
+        let value: u64 = rng.gen();
+        let rseed = RandomSeed::random(&mut rng);
+        Note {
+            note_type,
+            app_data_dynamic,
+            value,
+            nk_container: nk,
+            is_merkle_checked: true,
+            psi: rseed.get_psi(&rho),
+            rcm: rseed.get_rcm(&rho),
+            rho,
+        }
+    }
+
+    pub fn random_output_note<R: RngCore>(mut rng: R, rho: Nullifier) -> Note {
+        let nk_com = NullifierKeyContainer::from_commitment(pallas::Base::random(&mut rng));
+        let note_type = {
+            let app_vk = pallas::Base::random(&mut rng);
+            let app_data_static = pallas::Base::random(&mut rng);
+            NoteType::new(app_vk, app_data_static)
+        };
+        let app_data_dynamic = pallas::Base::random(&mut rng);
+        let value: u64 = rng.gen();
+        let rseed = RandomSeed::random(&mut rng);
+        Note {
+            note_type,
+            app_data_dynamic,
+            value,
+            nk_container: nk_com,
+            is_merkle_checked: true,
+            psi: rseed.get_psi(&rho),
+            rcm: rseed.get_rcm(&rho),
+            rho,
+        }
+    }
+}
+
 #[test]
 fn test_halo2_sudoku_app_vp_circuit_init() {
+    use crate::app_vp::tests::{random_input_note, random_output_note};
     use halo2_proofs::dev::MockProver;
     use rand::rngs::OsRng;
-    use taiga_halo2::note::tests::{random_input_note, random_output_note};
 
     let mut rng = OsRng;
     let circuit = {
@@ -607,7 +663,7 @@ fn test_halo2_sudoku_app_vp_circuit_init() {
         SudokuAppValidityPredicateCircuit {
             owned_note_pub_id,
             input_notes,
-            output_notes,
+            output_notes: output_notes.try_into().unwrap(),
             encoded_init_state,
             previous_state,
             current_state,
@@ -621,14 +677,18 @@ fn test_halo2_sudoku_app_vp_circuit_init() {
 
 #[test]
 fn test_halo2_sudoku_app_vp_circuit_update() {
+    use crate::app_vp::tests::{random_input_note, random_output_note};
     use halo2_proofs::dev::MockProver;
     use rand::rngs::OsRng;
 
     let mut rng = OsRng;
     // Construct circuit
     let circuit = {
-        let mut input_notes = [(); NUM_NOTE].map(|_| Note::dummy(&mut rng));
-        let mut output_notes = [(); NUM_NOTE].map(|_| Note::dummy(&mut rng));
+        let mut input_notes = [(); NUM_NOTE].map(|_| random_input_note(&mut rng));
+        let mut output_notes = input_notes
+            .iter()
+            .map(|input| random_output_note(&mut rng, input.get_nf().unwrap()))
+            .collect::<Vec<_>>();
         let init_state = SudokuState {
             state: [
                 [5, 0, 1, 6, 7, 2, 4, 3, 9],
@@ -679,7 +739,7 @@ fn test_halo2_sudoku_app_vp_circuit_update() {
         SudokuAppValidityPredicateCircuit {
             owned_note_pub_id: input_notes[0].get_nf().unwrap().inner(),
             input_notes,
-            output_notes,
+            output_notes: output_notes.try_into().unwrap(),
             encoded_init_state,
             previous_state,
             current_state,
@@ -693,14 +753,14 @@ fn test_halo2_sudoku_app_vp_circuit_update() {
 
 #[test]
 fn halo2_sudoku_app_vp_circuit_final() {
+    use crate::app_vp::tests::{random_input_note, random_output_note};
     use halo2_proofs::dev::MockProver;
 
     let mut rng = OsRng;
     // Construct circuit
     let circuit = {
-        use taiga_halo2::note::tests::{random_input_note, random_output_note};
-        let input_notes = [(); NUM_NOTE].map(|_| random_input_note(&mut rng));
-        let output_notes = input_notes
+        let mut input_notes = [(); NUM_NOTE].map(|_| random_input_note(&mut rng));
+        let mut output_notes = input_notes
             .iter()
             .map(|input| random_output_note(&mut rng, input.get_nf().unwrap()))
             .collect::<Vec<_>>();
@@ -754,7 +814,7 @@ fn halo2_sudoku_app_vp_circuit_final() {
         SudokuAppValidityPredicateCircuit {
             owned_note_pub_id: input_notes[0].get_nf().unwrap().inner(),
             input_notes,
-            output_notes,
+            output_notes: output_notes.try_into().unwrap(),
             encoded_init_state,
             previous_state,
             current_state,

--- a/taiga_halo2/examples/taiga_sudoku/dealer_intent_app_vp.rs
+++ b/taiga_halo2/examples/taiga_sudoku/dealer_intent_app_vp.rs
@@ -85,6 +85,7 @@ impl ValidityPredicateConfig for IntentAppValidityPredicateConfig {
 }
 
 impl DealerIntentValidityPredicateCircuit {
+    #![allow(dead_code)]
     pub fn compute_app_data_static(
         encoded_puzzle: pallas::Base,
         sudoku_app_vk: pallas::Base,
@@ -345,7 +346,7 @@ impl DealerIntentCheckConfig {
 
 #[test]
 fn test_halo2_dealer_intent_vp_circuit() {
-    use crate::note::tests::{random_input_note, random_output_note};
+    use crate::app_vp::tests::{random_input_note, random_output_note};
     use halo2_proofs::dev::MockProver;
     use rand::rngs::OsRng;
 
@@ -357,7 +358,7 @@ fn test_halo2_dealer_intent_vp_circuit() {
             .map(|input| random_output_note(&mut rng, input.get_nf().unwrap()))
             .collect::<Vec<_>>();
         let encoded_puzzle = pallas::Base::random(&mut rng);
-        let sudoku_app_vk = ValidityPredicateVerifyingKey::dummy(&mut rng).get_compressed();
+        let sudoku_app_vk = pallas::Base::random(&mut rng);
         output_notes[0].note_type.app_data_static =
             DealerIntentValidityPredicateCircuit::compute_app_data_static(
                 encoded_puzzle,
@@ -368,7 +369,7 @@ fn test_halo2_dealer_intent_vp_circuit() {
         DealerIntentValidityPredicateCircuit {
             owned_note_pub_id,
             input_notes,
-            output_notes,
+            output_notes: output_notes.try_into().unwrap(),
             encoded_puzzle,
             sudoku_app_vk,
             encoded_solution,

--- a/taiga_halo2/examples/taiga_sudoku/main.rs
+++ b/taiga_halo2/examples/taiga_sudoku/main.rs
@@ -1,7 +1,4 @@
 pub mod app_vp;
 pub mod dealer_intent_app_vp;
 pub mod gadgets;
-use crate::app_vp::halo2_sudoku_app_vp_circuit_final;
-fn main() {
-    halo2_sudoku_app_vp_circuit_final();
-}
+fn main() {}

--- a/taiga_halo2/examples/tx_examples/cascaded_partial_transactions.rs
+++ b/taiga_halo2/examples/tx_examples/cascaded_partial_transactions.rs
@@ -66,7 +66,7 @@ pub fn create_transaction<R: RngCore + CryptoRng>(mut rng: R) -> Transaction {
         &bob_auth,
     );
 
-    let merkle_path = MerklePath::dummy(&mut rng, TAIGA_COMMITMENT_TREE_DEPTH);
+    let merkle_path = MerklePath::random(&mut rng, TAIGA_COMMITMENT_TREE_DEPTH);
 
     // The first partial transaction:
     // Alice consumes 1 "BTC" and 2 "ETH".

--- a/taiga_halo2/examples/tx_examples/main.rs
+++ b/taiga_halo2/examples/tx_examples/main.rs
@@ -4,18 +4,18 @@ mod token;
 mod token_swap_with_intent;
 mod token_swap_without_intent;
 fn main() {
-    use rand::rngs::OsRng;
+    // use rand::rngs::OsRng;
 
-    let rng = OsRng;
-    let tx = token_swap_without_intent::create_token_swap_transaction(rng);
-    tx.execute().unwrap();
+    // let rng = OsRng;
+    // let tx = token_swap_without_intent::create_token_swap_transaction(rng);
+    // tx.execute().unwrap();
 
-    let tx = token_swap_with_intent::create_token_swap_intent_transaction(rng);
-    tx.execute().unwrap();
+    // let tx = token_swap_with_intent::create_token_swap_intent_transaction(rng);
+    // tx.execute().unwrap();
 
-    let tx = partial_fulfillment_token_swap::create_token_swap_transaction(rng);
-    tx.execute().unwrap();
+    // let tx = partial_fulfillment_token_swap::create_token_swap_transaction(rng);
+    // tx.execute().unwrap();
 
-    let tx = cascaded_partial_transactions::create_transaction(rng);
-    tx.execute().unwrap();
+    // let tx = cascaded_partial_transactions::create_transaction(rng);
+    // tx.execute().unwrap();
 }

--- a/taiga_halo2/examples/tx_examples/main.rs
+++ b/taiga_halo2/examples/tx_examples/main.rs
@@ -4,18 +4,18 @@ mod token;
 mod token_swap_with_intent;
 mod token_swap_without_intent;
 fn main() {
-    // use rand::rngs::OsRng;
+    use rand::rngs::OsRng;
 
-    // let rng = OsRng;
-    // let tx = token_swap_without_intent::create_token_swap_transaction(rng);
-    // tx.execute().unwrap();
+    let rng = OsRng;
+    let tx = token_swap_without_intent::create_token_swap_transaction(rng);
+    tx.execute().unwrap();
 
-    // let tx = token_swap_with_intent::create_token_swap_intent_transaction(rng);
-    // tx.execute().unwrap();
+    let tx = token_swap_with_intent::create_token_swap_intent_transaction(rng);
+    tx.execute().unwrap();
 
-    // let tx = partial_fulfillment_token_swap::create_token_swap_transaction(rng);
-    // tx.execute().unwrap();
+    let tx = partial_fulfillment_token_swap::create_token_swap_transaction(rng);
+    tx.execute().unwrap();
 
-    // let tx = cascaded_partial_transactions::create_transaction(rng);
-    // tx.execute().unwrap();
+    let tx = cascaded_partial_transactions::create_transaction(rng);
+    tx.execute().unwrap();
 }

--- a/taiga_halo2/examples/tx_examples/partial_fulfillment_token_swap.rs
+++ b/taiga_halo2/examples/tx_examples/partial_fulfillment_token_swap.rs
@@ -61,9 +61,9 @@ pub fn create_token_intent_ptx<R: RngCore>(
     );
 
     // padding the zero notes
-    let padding_input_note = Note::dummy_zero_note(&mut rng, rho);
+    let padding_input_note = Note::random_padding_input_note(&mut rng);
     let padding_input_note_nf = padding_input_note.get_nf().unwrap();
-    let padding_output_note = Note::dummy_zero_note(&mut rng, padding_input_note_nf);
+    let padding_output_note = Note::random_padding_output_note(&mut rng, padding_input_note_nf);
 
     let input_notes = [input_note, padding_input_note];
     let output_notes = [intent_note, padding_output_note];
@@ -151,8 +151,7 @@ pub fn consume_token_intent_ptx<R: RngCore>(
     assert_eq!(address, input_address);
 
     // padding the zero note
-    let rho = Nullifier::new(pallas::Base::random(&mut rng));
-    let padding_input_note = Note::dummy_zero_note(&mut rng, rho);
+    let padding_input_note = Note::random_padding_input_note(&mut rng);
     let padding_input_note_nf = padding_input_note.get_nf().unwrap();
     let returned_note = create_random_token_note(
         &mut rng,
@@ -162,7 +161,7 @@ pub fn consume_token_intent_ptx<R: RngCore>(
         input_nk,
         &output_auth,
     );
-    // let padding_output_note = Note::dummy_zero_note(&mut rng, padding_input_note_nf);
+    // let padding_output_note = Note::random_padding_input_note(&mut rng, padding_input_note_nf);
 
     let input_notes = [intent_note, padding_input_note];
     let output_notes = [bought_note, returned_note];

--- a/taiga_halo2/examples/tx_examples/partial_fulfillment_token_swap.rs
+++ b/taiga_halo2/examples/tx_examples/partial_fulfillment_token_swap.rs
@@ -68,7 +68,7 @@ pub fn create_token_intent_ptx<R: RngCore>(
     let input_notes = [input_note, padding_input_note];
     let output_notes = [intent_note, padding_output_note];
 
-    let merkle_path = MerklePath::dummy(&mut rng, TAIGA_COMMITMENT_TREE_DEPTH);
+    let merkle_path = MerklePath::random(&mut rng, TAIGA_COMMITMENT_TREE_DEPTH);
 
     // Create the input note proving info
     let input_note_proving_info = generate_input_token_note_proving_info(
@@ -166,7 +166,7 @@ pub fn consume_token_intent_ptx<R: RngCore>(
     let input_notes = [intent_note, padding_input_note];
     let output_notes = [bought_note, returned_note];
 
-    let merkle_path = MerklePath::dummy(&mut rng, TAIGA_COMMITMENT_TREE_DEPTH);
+    let merkle_path = MerklePath::random(&mut rng, TAIGA_COMMITMENT_TREE_DEPTH);
 
     // Create the intent note proving info
     let intent_note_proving_info = {

--- a/taiga_halo2/examples/tx_examples/token.rs
+++ b/taiga_halo2/examples/tx_examples/token.rs
@@ -79,9 +79,9 @@ pub fn create_token_swap_ptx<R: RngCore>(
     );
 
     // padding the zero notes
-    let padding_input_note = Note::dummy_zero_note(&mut rng, rho);
+    let padding_input_note = Note::random_padding_input_note(&mut rng);
     let padding_input_note_nf = padding_input_note.get_nf().unwrap();
-    let padding_output_note = Note::dummy_zero_note(&mut rng, padding_input_note_nf);
+    let padding_output_note = Note::random_padding_output_note(&mut rng, padding_input_note_nf);
 
     let input_notes = [input_note, padding_input_note];
     let output_notes = [output_note, padding_output_note];

--- a/taiga_halo2/examples/tx_examples/token.rs
+++ b/taiga_halo2/examples/tx_examples/token.rs
@@ -87,7 +87,7 @@ pub fn create_token_swap_ptx<R: RngCore>(
     let output_notes = [output_note, padding_output_note];
 
     // Generate proving info
-    let merkle_path = MerklePath::dummy(&mut rng, TAIGA_COMMITMENT_TREE_DEPTH);
+    let merkle_path = MerklePath::random(&mut rng, TAIGA_COMMITMENT_TREE_DEPTH);
 
     // Create the input note proving info
     let input_note_proving_info = generate_input_token_note_proving_info(

--- a/taiga_halo2/examples/tx_examples/token_swap_with_intent.rs
+++ b/taiga_halo2/examples/tx_examples/token_swap_with_intent.rs
@@ -69,9 +69,9 @@ pub fn create_token_intent_ptx<R: RngCore>(
     );
 
     // padding the zero notes
-    let padding_input_note = Note::dummy_zero_note(&mut rng, rho);
+    let padding_input_note = Note::random_padding_input_note(&mut rng);
     let padding_input_note_nf = padding_input_note.get_nf().unwrap();
-    let padding_output_note = Note::dummy_zero_note(&mut rng, padding_input_note_nf);
+    let padding_output_note = Note::random_padding_output_note(&mut rng, padding_input_note_nf);
 
     let input_notes = [input_note, padding_input_note];
     let output_notes = [intent_note, padding_output_note];
@@ -166,10 +166,9 @@ pub fn consume_token_intent_ptx<R: RngCore>(
     assert_eq!(address, input_address);
 
     // padding the zero notes
-    let rho = Nullifier::new(pallas::Base::random(&mut rng));
-    let padding_input_note = Note::dummy_zero_note(&mut rng, rho);
+    let padding_input_note = Note::random_padding_input_note(&mut rng);
     let padding_input_note_nf = padding_input_note.get_nf().unwrap();
-    let padding_output_note = Note::dummy_zero_note(&mut rng, padding_input_note_nf);
+    let padding_output_note = Note::random_padding_output_note(&mut rng, padding_input_note_nf);
 
     let input_notes = [intent_note, padding_input_note];
     let output_notes = [output_note, padding_output_note];

--- a/taiga_halo2/examples/tx_examples/token_swap_with_intent.rs
+++ b/taiga_halo2/examples/tx_examples/token_swap_with_intent.rs
@@ -76,7 +76,7 @@ pub fn create_token_intent_ptx<R: RngCore>(
     let input_notes = [input_note, padding_input_note];
     let output_notes = [intent_note, padding_output_note];
 
-    let merkle_path = MerklePath::dummy(&mut rng, TAIGA_COMMITMENT_TREE_DEPTH);
+    let merkle_path = MerklePath::random(&mut rng, TAIGA_COMMITMENT_TREE_DEPTH);
 
     // Create the input note proving info
     let input_note_proving_info = generate_input_token_note_proving_info(
@@ -173,7 +173,7 @@ pub fn consume_token_intent_ptx<R: RngCore>(
     let input_notes = [intent_note, padding_input_note];
     let output_notes = [output_note, padding_output_note];
 
-    let merkle_path = MerklePath::dummy(&mut rng, TAIGA_COMMITMENT_TREE_DEPTH);
+    let merkle_path = MerklePath::random(&mut rng, TAIGA_COMMITMENT_TREE_DEPTH);
 
     // Create the intent note proving info
     let intent_note_proving_info = {

--- a/taiga_halo2/src/action.rs
+++ b/taiga_halo2/src/action.rs
@@ -1,8 +1,6 @@
 use crate::{
     circuit::action_circuit::ActionCircuit,
-    constant::TAIGA_COMMITMENT_TREE_DEPTH,
-    merkle_tree::MerklePath,
-    note::{InputNoteProvingInfo, Note, OutputNoteProvingInfo},
+    note::{InputNoteProvingInfo, OutputNoteProvingInfo},
     nullifier::Nullifier,
     value_commitment::ValueCommitment,
 };
@@ -96,24 +94,6 @@ impl ActionInfo {
         self.rcv
     }
 
-    pub fn dummy<R: RngCore>(mut rng: R) -> Self {
-        use crate::circuit::vp_examples::TrivialValidityPredicateCircuit;
-        let input_note = Note::dummy(&mut rng);
-        let output_proving_info =
-            OutputNoteProvingInfo::dummy(&mut rng, input_note.get_nf().unwrap());
-        let merkle_path = MerklePath::dummy(&mut rng, TAIGA_COMMITMENT_TREE_DEPTH);
-        let app_vp_proving_info = Box::new(TrivialValidityPredicateCircuit::dummy(&mut rng));
-        let app_vp_proving_info_dynamic = vec![];
-        let input_proving_info = InputNoteProvingInfo::new(
-            input_note,
-            merkle_path,
-            app_vp_proving_info,
-            app_vp_proving_info_dynamic,
-        );
-
-        ActionInfo::new(input_proving_info, output_proving_info, &mut rng)
-    }
-
     pub fn build(self) -> (ActionInstance, ActionCircuit) {
         let nf = self.input.note.get_nf().unwrap();
         assert_eq!(
@@ -139,5 +119,18 @@ impl ActionInfo {
         };
 
         (action, action_circuit)
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::ActionInfo;
+    use crate::note::tests::{random_input_proving_info, random_output_proving_info};
+    use rand::RngCore;
+    pub fn random_action_info<R: RngCore>(mut rng: R) -> ActionInfo {
+        let input_proving_info = random_input_proving_info(&mut rng);
+        let output_proving_info =
+            random_output_proving_info(&mut rng, input_proving_info.note.get_nf().unwrap());
+        ActionInfo::new(input_proving_info, output_proving_info, &mut rng)
     }
 }

--- a/taiga_halo2/src/action.rs
+++ b/taiga_halo2/src/action.rs
@@ -83,7 +83,20 @@ impl BorshDeserialize for ActionInstance {
 }
 
 impl ActionInfo {
-    // pub fn new()
+    pub fn new(
+        input_note: Note,
+        input_merkle_path: MerklePath,
+        output_note: Note,
+        rcv: pallas::Scalar,
+    ) -> Self {
+        Self {
+            input_note,
+            input_merkle_path,
+            output_note,
+            rcv,
+        }
+    }
+
     pub fn from_proving_info<R: RngCore>(
         input: InputNoteProvingInfo,
         output: OutputNoteProvingInfo,

--- a/taiga_halo2/src/action.rs
+++ b/taiga_halo2/src/action.rs
@@ -23,8 +23,6 @@ pub struct ActionInstance {
     pub cm_x: pallas::Base,
     /// net value commitment
     pub cv_net: ValueCommitment,
-    // TODO: The EncryptedNote.
-    // encrypted_note,
 }
 
 /// The information to build ActionInstance and ActionCircuit.
@@ -150,12 +148,18 @@ impl ActionInfo {
 #[cfg(test)]
 pub mod tests {
     use super::ActionInfo;
-    use crate::note::tests::{random_input_proving_info, random_output_proving_info};
+    use crate::constant::TAIGA_COMMITMENT_TREE_DEPTH;
+    use crate::merkle_tree::MerklePath;
+    use crate::note::tests::{random_input_note, random_output_note};
+    use halo2_proofs::arithmetic::Field;
+    use pasta_curves::pallas;
     use rand::RngCore;
+
     pub fn random_action_info<R: RngCore>(mut rng: R) -> ActionInfo {
-        let input_proving_info = random_input_proving_info(&mut rng);
-        let output_proving_info =
-            random_output_proving_info(&mut rng, input_proving_info.note.get_nf().unwrap());
-        ActionInfo::from_proving_info(input_proving_info, output_proving_info, &mut rng)
+        let input_note = random_input_note(&mut rng);
+        let output_note = random_output_note(&mut rng, input_note.get_nf().unwrap());
+        let input_merkle_path = MerklePath::random(&mut rng, TAIGA_COMMITMENT_TREE_DEPTH);
+        let rcv = pallas::Scalar::random(&mut rng);
+        ActionInfo::new(input_note, input_merkle_path, output_note, rcv)
     }
 }

--- a/taiga_halo2/src/circuit/action_circuit.rs
+++ b/taiga_halo2/src/circuit/action_circuit.rs
@@ -237,7 +237,7 @@ impl Circuit<pallas::Base> for ActionCircuit {
 
 #[test]
 fn test_halo2_action_circuit() {
-    use crate::action::ActionInfo;
+    use crate::action::tests::random_action_info;
     use crate::constant::{
         ACTION_CIRCUIT_PARAMS_SIZE, ACTION_PROVING_KEY, ACTION_VERIFYING_KEY, SETUP_PARAMS_MAP,
     };
@@ -247,7 +247,7 @@ fn test_halo2_action_circuit() {
     use rand::rngs::OsRng;
 
     let mut rng = OsRng;
-    let action_info = ActionInfo::dummy(&mut rng);
+    let action_info = random_action_info(&mut rng);
     let (action, action_circuit) = action_info.build();
     let instances = vec![action.to_instance()];
     let prover =

--- a/taiga_halo2/src/circuit/action_circuit.rs
+++ b/taiga_halo2/src/circuit/action_circuit.rs
@@ -38,7 +38,7 @@ pub struct ActionCircuit {
     /// Input note
     pub input_note: Note,
     /// The authorization path of input note
-    pub auth_path: [(pallas::Base, LR); TAIGA_COMMITMENT_TREE_DEPTH],
+    pub merkle_path: [(pallas::Base, LR); TAIGA_COMMITMENT_TREE_DEPTH],
     /// Output note
     pub output_note: Note,
     /// random scalar for net value commitment
@@ -159,7 +159,7 @@ impl Circuit<pallas::Base> for ActionCircuit {
             layouter.namespace(|| "poseidon merkle"),
             merkle_chip,
             input_note_variables.cm_x,
-            &self.auth_path,
+            &self.merkle_path,
         )?;
 
         // TODO: user send address VP commitment and application VP commitment

--- a/taiga_halo2/src/circuit/gadgets/target_note_variable.rs
+++ b/taiga_halo2/src/circuit/gadgets/target_note_variable.rs
@@ -102,18 +102,14 @@ impl GetOwnedNoteVariableConfig {
                 nf_or_cm_minus_owned_note_pub_id_vec
                     .clone()
                     .into_iter()
-                    .zip(inv_vec.into_iter())
+                    .zip(inv_vec)
                     .map(|(nf_or_cm_minus_owned_note_pub_id, inv)| {
                         one.clone() - nf_or_cm_minus_owned_note_pub_id * inv
                     })
                     .collect();
             let poly_vec: Vec<Expression<pasta_curves::Fp>> = nf_or_cm_minus_owned_note_pub_id_vec
                 .into_iter()
-                .zip(
-                    nf_or_cm_minus_owned_note_pub_id_is_zero_vec
-                        .clone()
-                        .into_iter(),
-                )
+                .zip(nf_or_cm_minus_owned_note_pub_id_is_zero_vec.clone())
                 .map(|(nf_or_cm_minus_owned_note_pub_id, is_zero)| {
                     nf_or_cm_minus_owned_note_pub_id * is_zero
                 })
@@ -189,10 +185,7 @@ impl GetOwnedNoteVariableConfig {
         )?;
 
         let mut ret = Value::known(pallas::Base::zero());
-        for (pair, column) in note_variable_pairs
-            .iter()
-            .zip(self.note_variable_pairs.into_iter())
-        {
+        for (pair, column) in note_variable_pairs.iter().zip(self.note_variable_pairs) {
             pair.src_variable
                 .copy_advice(|| "nf or cm", region, column, offset + 1)?;
             pair.target_variable

--- a/taiga_halo2/src/circuit/merkle_circuit.rs
+++ b/taiga_halo2/src/circuit/merkle_circuit.rs
@@ -109,8 +109,7 @@ pub fn merkle_poseidon_gadget(
 #[test]
 fn test_halo2_merkle_circuit() {
     use crate::circuit::gadgets::assign_free_advice;
-    use crate::constant::TAIGA_COMMITMENT_TREE_DEPTH;
-    use crate::merkle_tree::{MerklePath, Node};
+    use crate::merkle_tree::{tests::random_merkle_path, MerklePath, Node};
     use halo2_gadgets::poseidon::{primitives as poseidon, Pow5Chip as PoseidonChip};
     use halo2_proofs::{
         arithmetic::Field,
@@ -206,7 +205,7 @@ fn test_halo2_merkle_circuit() {
     let mut rng = OsRng;
 
     let leaf = pallas::Base::random(rng);
-    let merkle_path = MerklePath::dummy(&mut rng, TAIGA_COMMITMENT_TREE_DEPTH);
+    let merkle_path = random_merkle_path(&mut rng);
 
     let circuit = MyCircuit { leaf, merkle_path };
 

--- a/taiga_halo2/src/circuit/merkle_circuit.rs
+++ b/taiga_halo2/src/circuit/merkle_circuit.rs
@@ -94,12 +94,11 @@ pub fn merkle_poseidon_gadget(
                 Value::known(is_left(e.1)),
             )?
         };
-        let poseidon_message = [pair.0, pair.1];
 
         cur = poseidon_hash_gadget(
             chip.config().poseidon_config.clone(),
             layouter.namespace(|| "merkle poseidon hash"),
-            poseidon_message,
+            [pair.0, pair.1],
         )?;
     }
 

--- a/taiga_halo2/src/circuit/vp_examples.rs
+++ b/taiga_halo2/src/circuit/vp_examples.rs
@@ -102,7 +102,7 @@ pub mod tests {
     }
 
     #[test]
-    fn test_halo2_dummy_vp_circuit() {
+    fn test_halo2_trivial_vp_circuit() {
         use crate::circuit::vp_circuit::ValidityPredicateInfo;
         use halo2_proofs::dev::MockProver;
         use rand::rngs::OsRng;

--- a/taiga_halo2/src/circuit/vp_examples.rs
+++ b/taiga_halo2/src/circuit/vp_examples.rs
@@ -16,7 +16,6 @@ use halo2_proofs::{
 use lazy_static::lazy_static;
 use pasta_curves::pallas;
 use rand::rngs::OsRng;
-use rand::RngCore;
 
 pub mod cascade_intent;
 mod field_addition;
@@ -41,10 +40,11 @@ pub struct TrivialValidityPredicateCircuit {
 }
 
 impl TrivialValidityPredicateCircuit {
-    pub fn dummy<R: RngCore>(mut rng: R) -> Self {
-        let owned_note_pub_id = pallas::Base::zero();
-        let input_notes = [(); NUM_NOTE].map(|_| Note::dummy(&mut rng));
-        let output_notes = [(); NUM_NOTE].map(|_| Note::dummy(&mut rng));
+    pub fn new(
+        owned_note_pub_id: pallas::Base,
+        input_notes: [Note; NUM_NOTE],
+        output_notes: [Note; NUM_NOTE],
+    ) -> Self {
         Self {
             owned_note_pub_id,
             input_notes,
@@ -77,15 +77,41 @@ impl ValidityPredicateCircuit for TrivialValidityPredicateCircuit {
 
 vp_circuit_impl!(TrivialValidityPredicateCircuit);
 
-#[test]
-fn test_halo2_dummy_vp_circuit() {
-    use halo2_proofs::dev::MockProver;
-    use rand::rngs::OsRng;
+#[cfg(test)]
+pub mod tests {
+    use super::TrivialValidityPredicateCircuit;
+    use crate::{
+        constant::NUM_NOTE,
+        note::tests::{random_input_note, random_output_note},
+    };
+    use ff::Field;
+    use pasta_curves::pallas;
+    use rand::RngCore;
+    pub fn random_trivial_vp_circuit<R: RngCore>(mut rng: R) -> TrivialValidityPredicateCircuit {
+        let owned_note_pub_id = pallas::Base::random(&mut rng);
+        let input_notes = [(); NUM_NOTE].map(|_| random_input_note(&mut rng));
+        let output_notes = input_notes
+            .iter()
+            .map(|input| random_output_note(&mut rng, input.get_nf().unwrap()))
+            .collect::<Vec<_>>();
+        TrivialValidityPredicateCircuit::new(
+            owned_note_pub_id,
+            input_notes,
+            output_notes.try_into().unwrap(),
+        )
+    }
 
-    let mut rng = OsRng;
-    let circuit = TrivialValidityPredicateCircuit::dummy(&mut rng);
-    let instances = circuit.get_instances();
+    #[test]
+    fn test_halo2_dummy_vp_circuit() {
+        use crate::circuit::vp_circuit::ValidityPredicateInfo;
+        use halo2_proofs::dev::MockProver;
+        use rand::rngs::OsRng;
 
-    let prover = MockProver::<pallas::Base>::run(12, &circuit, vec![instances]).unwrap();
-    assert_eq!(prover.verify(), Ok(()));
+        let mut rng = OsRng;
+        let circuit = random_trivial_vp_circuit(&mut rng);
+        let instances = circuit.get_instances();
+
+        let prover = MockProver::<pallas::Base>::run(12, &circuit, vec![instances]).unwrap();
+        assert_eq!(prover.verify(), Ok(()));
+    }
 }

--- a/taiga_halo2/src/circuit/vp_examples/cascade_intent.rs
+++ b/taiga_halo2/src/circuit/vp_examples/cascade_intent.rs
@@ -23,7 +23,6 @@ use crate::{
     vp_vk::ValidityPredicateVerifyingKey,
 };
 use halo2_proofs::{
-    arithmetic::Field,
     circuit::{floor_planner, Layouter, Value},
     plonk::{keygen_pk, keygen_vk, Circuit, ConstraintSystem, Error},
 };
@@ -52,23 +51,6 @@ impl CascadeIntentValidityPredicateCircuit {
     // We can encode at most three notes to app_data_static if needed.
     pub fn encode_app_data_static(cascade_note_cm: pallas::Base) -> pallas::Base {
         cascade_note_cm
-    }
-
-    // TODO: Move the random function to the test mod
-    pub fn random<R: RngCore>(mut rng: R) -> Self {
-        let output_notes = [(); NUM_NOTE].map(|_| Note::dummy(&mut rng));
-        let cascade_input_note = Note::dummy(&mut rng);
-        let cascade_note_cm = cascade_input_note.commitment().get_x();
-        let rho = Nullifier::new(pallas::Base::random(&mut rng));
-        let nk = NullifierKeyContainer::random_key(&mut rng);
-        let intent_note = create_intent_note(&mut rng, cascade_note_cm, rho, nk);
-        let input_notes = [intent_note, cascade_input_note];
-        Self {
-            owned_note_pub_id: input_notes[0].get_nf().unwrap().inner(),
-            input_notes,
-            output_notes,
-            cascade_note_cm,
-        }
     }
 }
 
@@ -172,11 +154,31 @@ pub fn create_intent_note<R: RngCore>(
 
 #[test]
 fn test_halo2_cascade_intent_vp_circuit() {
+    use crate::note::tests::{random_input_note, random_output_note};
+    use halo2_proofs::arithmetic::Field;
     use halo2_proofs::dev::MockProver;
     use rand::rngs::OsRng;
 
     let mut rng = OsRng;
-    let circuit = CascadeIntentValidityPredicateCircuit::random(&mut rng);
+    let circuit = {
+        let cascade_input_note = random_input_note(&mut rng);
+        let cascade_note_cm = cascade_input_note.commitment().get_x();
+        let rho = Nullifier::new(pallas::Base::random(&mut rng));
+        let nk = NullifierKeyContainer::random_key(&mut rng);
+        let intent_note = create_intent_note(&mut rng, cascade_note_cm, rho, nk);
+        let input_notes = [intent_note, cascade_input_note];
+        let output_notes = input_notes
+            .iter()
+            .map(|input| random_output_note(&mut rng, input.get_nf().unwrap()))
+            .collect::<Vec<_>>();
+
+        CascadeIntentValidityPredicateCircuit {
+            owned_note_pub_id: input_notes[0].get_nf().unwrap().inner(),
+            input_notes,
+            output_notes: output_notes.try_into().unwrap(),
+            cascade_note_cm,
+        }
+    };
     let instances = circuit.get_instances();
 
     let prover = MockProver::<pallas::Base>::run(12, &circuit, vec![instances]).unwrap();

--- a/taiga_halo2/src/circuit/vp_examples/field_addition.rs
+++ b/taiga_halo2/src/circuit/vp_examples/field_addition.rs
@@ -16,13 +16,11 @@ use crate::{
     vp_vk::ValidityPredicateVerifyingKey,
 };
 use halo2_proofs::{
-    arithmetic::Field,
     circuit::{floor_planner, Layouter, Value},
     plonk::{keygen_pk, keygen_vk, Circuit, ConstraintSystem, Error},
 };
 use pasta_curves::pallas;
 use rand::rngs::OsRng;
-use rand::RngCore;
 
 // FieldAdditionValidityPredicateCircuit with a trivial constraint a + b = c.
 #[derive(Clone, Debug, Default)]
@@ -32,23 +30,6 @@ struct FieldAdditionValidityPredicateCircuit {
     output_notes: [Note; NUM_NOTE],
     a: pallas::Base,
     b: pallas::Base,
-}
-
-impl FieldAdditionValidityPredicateCircuit {
-    pub fn dummy<R: RngCore>(mut rng: R) -> Self {
-        let input_notes = [(); NUM_NOTE].map(|_| Note::dummy(&mut rng));
-        let output_notes = [(); NUM_NOTE].map(|_| Note::dummy(&mut rng));
-        let a = pallas::Base::random(&mut rng);
-        let b = pallas::Base::random(&mut rng);
-        let owned_note_pub_id = pallas::Base::zero();
-        Self {
-            owned_note_pub_id,
-            input_notes,
-            output_notes,
-            a,
-            b,
-        }
-    }
 }
 
 impl ValidityPredicateInfo for FieldAdditionValidityPredicateCircuit {
@@ -114,11 +95,29 @@ vp_circuit_impl!(FieldAdditionValidityPredicateCircuit);
 
 #[test]
 fn test_halo2_addition_vp_circuit() {
+    use crate::note::tests::{random_input_note, random_output_note};
+    use halo2_proofs::arithmetic::Field;
     use halo2_proofs::dev::MockProver;
     use rand::rngs::OsRng;
 
     let mut rng = OsRng;
-    let circuit = FieldAdditionValidityPredicateCircuit::dummy(&mut rng);
+    let circuit = {
+        let input_notes = [(); NUM_NOTE].map(|_| random_input_note(&mut rng));
+        let output_notes = input_notes
+            .iter()
+            .map(|input| random_output_note(&mut rng, input.get_nf().unwrap()))
+            .collect::<Vec<_>>();
+        let a = pallas::Base::random(&mut rng);
+        let b = pallas::Base::random(&mut rng);
+        let owned_note_pub_id = pallas::Base::random(&mut rng);
+        FieldAdditionValidityPredicateCircuit {
+            owned_note_pub_id,
+            input_notes,
+            output_notes: output_notes.try_into().unwrap(),
+            a,
+            b,
+        }
+    };
     let instances = circuit.get_instances();
 
     let prover = MockProver::<pallas::Base>::run(12, &circuit, vec![instances]).unwrap();

--- a/taiga_halo2/src/circuit/vp_examples/or_relation_intent.rs
+++ b/taiga_halo2/src/circuit/vp_examples/or_relation_intent.rs
@@ -282,8 +282,7 @@ pub fn create_intent_note<R: RngCore>(
 #[test]
 fn test_halo2_or_relation_intent_vp_circuit() {
     use crate::{
-        circuit::vp_examples::token::COMPRESSED_TOKEN_VK,
-        note::tests::{random_output_note, random_zero_note},
+        circuit::vp_examples::token::COMPRESSED_TOKEN_VK, note::tests::random_output_note,
         nullifier::tests::random_nullifier,
     };
     use halo2_proofs::arithmetic::Field;
@@ -320,8 +319,7 @@ fn test_halo2_or_relation_intent_vp_circuit() {
             rho,
             nk,
         );
-        let padding_rho = random_nullifier(&mut rng);
-        let padding_input_note = random_zero_note(&mut rng, padding_rho);
+        let padding_input_note = Note::random_padding_input_note(&mut rng);
         let input_notes = [intent_note, padding_input_note];
         OrRelationIntentValidityPredicateCircuit {
             owned_note_pub_id: input_notes[0].get_nf().unwrap().inner(),

--- a/taiga_halo2/src/circuit/vp_examples/or_relation_intent.rs
+++ b/taiga_halo2/src/circuit/vp_examples/or_relation_intent.rs
@@ -14,9 +14,7 @@ use crate::{
             VPVerifyingInfo, ValidityPredicateCircuit, ValidityPredicateConfig,
             ValidityPredicateInfo, ValidityPredicateVerifyingInfo,
         },
-        vp_examples::token::{
-            transfrom_token_name_to_token_property, COMPRESSED_TOKEN_VK, TOKEN_VK,
-        },
+        vp_examples::token::{transfrom_token_name_to_token_property, TOKEN_VK},
     },
     constant::{NUM_NOTE, SETUP_PARAMS_MAP},
     note::{Note, RandomSeed},
@@ -26,7 +24,6 @@ use crate::{
     vp_vk::ValidityPredicateVerifyingKey,
 };
 use halo2_proofs::{
-    arithmetic::Field,
     circuit::{floor_planner, Layouter, Value},
     plonk::{keygen_pk, keygen_vk, Circuit, ConstraintSystem, Error},
 };
@@ -80,45 +77,6 @@ impl OrRelationIntentValidityPredicateCircuit {
             pallas::Base::zero(),
             pallas::Base::zero(),
         ])
-    }
-
-    // TODO: Move the random function to the test mod
-    pub fn random<R: RngCore>(mut rng: R) -> Self {
-        let mut output_notes = [(); NUM_NOTE].map(|_| Note::dummy(&mut rng));
-        let condition1 = Condition {
-            token_name: "token1".to_string(),
-            token_value: 1u64,
-        };
-        let condition2 = Condition {
-            token_name: "token2".to_string(),
-            token_value: 2u64,
-        };
-        output_notes[0].note_type.app_vk = *COMPRESSED_TOKEN_VK;
-        output_notes[0].note_type.app_data_static =
-            transfrom_token_name_to_token_property(&condition1.token_name);
-        output_notes[0].value = condition1.token_value;
-        let receiver_address = output_notes[0].get_address();
-
-        let rho = Nullifier::new(pallas::Base::random(&mut rng));
-        let nk = NullifierKeyContainer::random_key(&mut rng);
-        let intent_note = create_intent_note(
-            &mut rng,
-            &condition1,
-            &condition2,
-            receiver_address,
-            rho,
-            nk,
-        );
-        let padding_input_note = Note::dummy(&mut rng);
-        let input_notes = [intent_note, padding_input_note];
-        Self {
-            owned_note_pub_id: input_notes[0].get_nf().unwrap().inner(),
-            input_notes,
-            output_notes,
-            condition1,
-            condition2,
-            receiver_address,
-        }
     }
 }
 
@@ -323,11 +281,57 @@ pub fn create_intent_note<R: RngCore>(
 
 #[test]
 fn test_halo2_or_relation_intent_vp_circuit() {
+    use crate::{
+        circuit::vp_examples::token::COMPRESSED_TOKEN_VK,
+        note::tests::{random_output_note, random_zero_note},
+        nullifier::tests::random_nullifier,
+    };
+    use halo2_proofs::arithmetic::Field;
     use halo2_proofs::dev::MockProver;
     use rand::rngs::OsRng;
 
     let mut rng = OsRng;
-    let circuit = OrRelationIntentValidityPredicateCircuit::random(&mut rng);
+    let circuit = {
+        let mut output_notes = [(); NUM_NOTE].map(|_| {
+            let padding_rho = random_nullifier(&mut rng);
+            random_output_note(&mut rng, padding_rho)
+        });
+        let condition1 = Condition {
+            token_name: "token1".to_string(),
+            token_value: 1u64,
+        };
+        let condition2 = Condition {
+            token_name: "token2".to_string(),
+            token_value: 2u64,
+        };
+        output_notes[0].note_type.app_vk = *COMPRESSED_TOKEN_VK;
+        output_notes[0].note_type.app_data_static =
+            transfrom_token_name_to_token_property(&condition1.token_name);
+        output_notes[0].value = condition1.token_value;
+        let receiver_address = output_notes[0].get_address();
+
+        let rho = Nullifier::new(pallas::Base::random(&mut rng));
+        let nk = NullifierKeyContainer::random_key(&mut rng);
+        let intent_note = create_intent_note(
+            &mut rng,
+            &condition1,
+            &condition2,
+            receiver_address,
+            rho,
+            nk,
+        );
+        let padding_rho = random_nullifier(&mut rng);
+        let padding_input_note = random_zero_note(&mut rng, padding_rho);
+        let input_notes = [intent_note, padding_input_note];
+        OrRelationIntentValidityPredicateCircuit {
+            owned_note_pub_id: input_notes[0].get_nf().unwrap().inner(),
+            input_notes,
+            output_notes,
+            condition1,
+            condition2,
+            receiver_address,
+        }
+    };
     let instances = circuit.get_instances();
 
     let prover = MockProver::<pallas::Base>::run(12, &circuit, vec![instances]).unwrap();

--- a/taiga_halo2/src/circuit/vp_examples/partial_fulfillment_intent.rs
+++ b/taiga_halo2/src/circuit/vp_examples/partial_fulfillment_intent.rs
@@ -16,9 +16,7 @@ use crate::{
             VPVerifyingInfo, ValidityPredicateCircuit, ValidityPredicateConfig,
             ValidityPredicateInfo, ValidityPredicateVerifyingInfo,
         },
-        vp_examples::token::{
-            transfrom_token_name_to_token_property, Token, COMPRESSED_TOKEN_VK, TOKEN_VK,
-        },
+        vp_examples::token::{transfrom_token_name_to_token_property, Token, TOKEN_VK},
     },
     constant::{NUM_NOTE, SETUP_PARAMS_MAP},
     note::{Note, RandomSeed},
@@ -28,7 +26,6 @@ use crate::{
     vp_vk::ValidityPredicateVerifyingKey,
 };
 use halo2_proofs::{
-    arithmetic::Field,
     circuit::{floor_planner, Layouter, Value},
     plonk::{keygen_pk, keygen_vk, Circuit, ConstraintSystem, Error},
 };
@@ -76,38 +73,6 @@ impl PartialFulfillmentIntentValidityPredicateCircuit {
             pallas::Base::zero(),
             pallas::Base::zero(),
         ])
-    }
-
-    // TODO: Move the random function to the test mod
-    pub fn random<R: RngCore>(mut rng: R) -> Self {
-        let mut output_notes = [(); NUM_NOTE].map(|_| Note::dummy(&mut rng));
-        let sell = Token {
-            name: "token1".to_string(),
-            value: 2u64,
-        };
-        let buy = Token {
-            name: "token2".to_string(),
-            value: 4u64,
-        };
-        output_notes[0].note_type.app_vk = *COMPRESSED_TOKEN_VK;
-        output_notes[0].note_type.app_data_static =
-            transfrom_token_name_to_token_property(&sell.name);
-        output_notes[0].value = sell.value;
-        let receiver_address = output_notes[0].get_address();
-
-        let rho = Nullifier::new(pallas::Base::random(&mut rng));
-        let nk = NullifierKeyContainer::random_key(&mut rng);
-        let intent_note = create_intent_note(&mut rng, &sell, &buy, receiver_address, rho, nk);
-        let padding_input_note = Note::dummy(&mut rng);
-        let input_notes = [intent_note, padding_input_note];
-        Self {
-            owned_note_pub_id: input_notes[0].get_nf().unwrap().inner(),
-            input_notes,
-            output_notes,
-            sell,
-            buy,
-            receiver_address,
-        }
     }
 }
 
@@ -469,6 +434,12 @@ pub fn create_intent_note<R: RngCore>(
 
 #[test]
 fn test_halo2_partial_fulfillment_intent_vp_circuit() {
+    use crate::{
+        circuit::vp_examples::token::COMPRESSED_TOKEN_VK,
+        note::tests::{random_input_note, random_zero_note},
+        nullifier::tests::random_nullifier,
+    };
+    use halo2_proofs::arithmetic::Field;
     use halo2_proofs::dev::MockProver;
     use rand::rngs::OsRng;
 
@@ -483,8 +454,7 @@ fn test_halo2_partial_fulfillment_intent_vp_circuit() {
         value: 4u64,
     };
 
-    let dummy_note = Note::dummy(&mut rng);
-    let mut sold_note = dummy_note;
+    let mut sold_note = random_input_note(&mut rng);
     sold_note.note_type.app_vk = *COMPRESSED_TOKEN_VK;
     sold_note.note_type.app_data_static = transfrom_token_name_to_token_property(&sell.name);
     sold_note.value = sell.value;
@@ -494,8 +464,11 @@ fn test_halo2_partial_fulfillment_intent_vp_circuit() {
     let intent_note = create_intent_note(&mut rng, &sell, &buy, receiver_address, rho, nk);
     // Creating intent test
     {
-        let input_notes = [sold_note, dummy_note];
-        let output_notes = [intent_note, dummy_note];
+        let padding_rho = random_nullifier(&mut rng);
+        let input_padding_note = random_zero_note(&mut rng, padding_rho);
+        let input_notes = [sold_note, input_padding_note];
+        let output_padding_note = random_zero_note(&mut rng, input_padding_note.get_nf().unwrap());
+        let output_notes = [intent_note, output_padding_note];
 
         let circuit = PartialFulfillmentIntentValidityPredicateCircuit {
             owned_note_pub_id: intent_note.commitment().get_x(),
@@ -514,7 +487,9 @@ fn test_halo2_partial_fulfillment_intent_vp_circuit() {
     // Consuming intent test
     {
         {
-            let input_notes = [intent_note, dummy_note];
+            let padding_rho = random_nullifier(&mut rng);
+            let input_padding_note = random_zero_note(&mut rng, padding_rho);
+            let input_notes = [intent_note, input_padding_note];
             let mut bought_note = sold_note;
             bought_note.note_type.app_data_static =
                 transfrom_token_name_to_token_property(&buy.name);
@@ -524,7 +499,9 @@ fn test_halo2_partial_fulfillment_intent_vp_circuit() {
             // full fulfillment
             {
                 bought_note.value = buy.value;
-                let output_notes = [bought_note, dummy_note];
+                let output_padding_note =
+                    random_zero_note(&mut rng, input_padding_note.get_nf().unwrap());
+                let output_notes = [bought_note, output_padding_note];
 
                 let circuit = PartialFulfillmentIntentValidityPredicateCircuit {
                     owned_note_pub_id: intent_note.get_nf().unwrap().inner(),

--- a/taiga_halo2/src/circuit/vp_examples/signature_verification.rs
+++ b/taiga_halo2/src/circuit/vp_examples/signature_verification.rs
@@ -9,7 +9,6 @@ use crate::{
             VPVerifyingInfo, ValidityPredicateCircuit, ValidityPredicateConfig,
             ValidityPredicateInfo, ValidityPredicateVerifyingInfo,
         },
-        vp_examples::receiver_vp::COMPRESSED_RECEIVER_VK,
     },
     constant::{TaigaFixedBasesFull, NUM_NOTE, SETUP_PARAMS_MAP},
     note::Note,
@@ -148,28 +147,6 @@ impl SignatureVerificationValidityPredicateCircuit {
             receiver_vp_vk,
         }
     }
-
-    // TODO: Move the random function to the test mod
-    pub fn random<R: RngCore>(mut rng: R) -> Self {
-        use crate::circuit::vp_examples::token::TokenAuthorization;
-
-        let mut input_notes = [(); NUM_NOTE].map(|_| Note::dummy(&mut rng));
-        let output_notes = [(); NUM_NOTE].map(|_| Note::dummy(&mut rng));
-        let sk = pallas::Scalar::random(&mut rng);
-        let auth_vk = pallas::Base::random(&mut rng);
-        let auth = TokenAuthorization::from_sk_vk(&sk, &auth_vk);
-        input_notes[0].app_data_dynamic = auth.to_app_data_dynamic();
-        let owned_note_pub_id = input_notes[0].get_nf().unwrap().inner();
-        Self::from_sk_and_sign(
-            &mut rng,
-            owned_note_pub_id,
-            input_notes,
-            output_notes,
-            auth_vk,
-            sk,
-            *COMPRESSED_RECEIVER_VK,
-        )
-    }
 }
 
 impl ValidityPredicateInfo for SignatureVerificationValidityPredicateCircuit {
@@ -298,11 +275,35 @@ vp_circuit_impl!(SignatureVerificationValidityPredicateCircuit);
 
 #[test]
 fn test_halo2_sig_verification_vp_circuit() {
+    use crate::circuit::vp_examples::{
+        receiver_vp::COMPRESSED_RECEIVER_VK, token::TokenAuthorization,
+    };
+    use crate::note::tests::{random_input_note, random_output_note};
     use halo2_proofs::dev::MockProver;
     use rand::rngs::OsRng;
 
     let mut rng = OsRng;
-    let circuit = SignatureVerificationValidityPredicateCircuit::random(&mut rng);
+    let circuit = {
+        let mut input_notes = [(); NUM_NOTE].map(|_| random_input_note(&mut rng));
+        let output_notes = input_notes
+            .iter()
+            .map(|input| random_output_note(&mut rng, input.get_nf().unwrap()))
+            .collect::<Vec<_>>();
+        let sk = pallas::Scalar::random(&mut rng);
+        let auth_vk = pallas::Base::random(&mut rng);
+        let auth = TokenAuthorization::from_sk_vk(&sk, &auth_vk);
+        input_notes[0].app_data_dynamic = auth.to_app_data_dynamic();
+        let owned_note_pub_id = input_notes[0].get_nf().unwrap().inner();
+        SignatureVerificationValidityPredicateCircuit::from_sk_and_sign(
+            &mut rng,
+            owned_note_pub_id,
+            input_notes,
+            output_notes.try_into().unwrap(),
+            auth_vk,
+            sk,
+            *COMPRESSED_RECEIVER_VK,
+        )
+    };
     let instances = circuit.get_instances();
 
     let prover = MockProver::<pallas::Base>::run(12, &circuit, vec![instances]).unwrap();

--- a/taiga_halo2/src/merkle_tree.rs
+++ b/taiga_halo2/src/merkle_tree.rs
@@ -93,7 +93,7 @@ pub struct MerklePath {
 
 impl MerklePath {
     /// Constructs a random dummy merkle path with depth. Only used in tests.
-    pub fn dummy(rng: &mut impl RngCore, depth: usize) -> Self {
+    pub fn random(rng: &mut impl RngCore, depth: usize) -> Self {
         let auth_path = (0..depth).map(|_| (Node::rand(rng), rng.gen())).collect();
         Self::from_path(auth_path)
     }
@@ -206,7 +206,7 @@ pub mod tests {
     use pasta_curves::Fp;
 
     pub fn random_merkle_path<R: RngCore>(mut rng: R) -> MerklePath {
-        MerklePath::dummy(&mut rng, TAIGA_COMMITMENT_TREE_DEPTH)
+        MerklePath::random(&mut rng, TAIGA_COMMITMENT_TREE_DEPTH)
     }
 
     #[test]

--- a/taiga_halo2/src/merkle_tree.rs
+++ b/taiga_halo2/src/merkle_tree.rs
@@ -92,13 +92,11 @@ pub struct MerklePath {
 }
 
 impl MerklePath {
-    /// Constructs a random dummy merkle path with depth.
-    // TODO: move it to test mod
+    /// Constructs a random dummy merkle path with depth. Only used in tests.
     pub fn dummy(rng: &mut impl RngCore, depth: usize) -> Self {
         let auth_path = (0..depth).map(|_| (Node::rand(rng), rng.gen())).collect();
         Self::from_path(auth_path)
     }
-
     /// Constructs a Merkle path directly from a path.
     pub fn from_path(auth_path: Vec<(Node, LR)>) -> Self {
         MerklePath { auth_path }
@@ -200,11 +198,16 @@ impl Default for MerklePath {
 }
 
 #[cfg(test)]
-mod tests {
+pub mod tests {
     use super::*;
+    use crate::constant::TAIGA_COMMITMENT_TREE_DEPTH;
     use crate::merkle_tree::Node;
     use halo2_gadgets::poseidon::primitives as poseidon;
     use pasta_curves::Fp;
+
+    pub fn random_merkle_path<R: RngCore>(mut rng: R) -> MerklePath {
+        MerklePath::dummy(&mut rng, TAIGA_COMMITMENT_TREE_DEPTH)
+    }
 
     #[test]
     // Test a Merkle tree with 4 leaves

--- a/taiga_halo2/src/note.rs
+++ b/taiga_halo2/src/note.rs
@@ -22,7 +22,7 @@ use pasta_curves::{
     group::{ff::PrimeFieldBits, Group, GroupEncoding},
     pallas,
 };
-use rand::{Rng, RngCore};
+use rand::RngCore;
 use std::{
     hash::{Hash, Hasher},
     io,
@@ -151,53 +151,15 @@ impl Note {
         }
     }
 
-    // TODO: remove it when optimizing the tests
-    pub fn dummy<R: RngCore>(mut rng: R) -> Self {
-        Self::dummy_input(&mut rng)
-    }
-
-    pub fn dummy_input<R: RngCore>(mut rng: R) -> Self {
-        let rho = Nullifier::new(pallas::Base::random(&mut rng));
-        let nk = NullifierKeyContainer::from_key(pallas::Base::random(&mut rng));
-        Self::dummy_from_parts(rng, rho, nk)
-    }
-
-    pub fn dummy_output<R: RngCore>(mut rng: R, rho: Nullifier) -> Self {
-        let nk_com = NullifierKeyContainer::from_commitment(pallas::Base::random(&mut rng));
-        Self::dummy_from_parts(rng, rho, nk_com)
-    }
-
-    pub fn dummy_from_parts<R: RngCore>(
-        mut rng: R,
-        rho: Nullifier,
-        nk_container: NullifierKeyContainer,
-    ) -> Self {
-        let app_vk = pallas::Base::random(&mut rng);
-        let app_data_static = pallas::Base::random(&mut rng);
-        let note_type = NoteType::new(app_vk, app_data_static);
-        let app_data_dynamic = pallas::Base::zero();
-        let value: u64 = rng.gen();
-        let rseed = RandomSeed::random(&mut rng);
-        Self {
-            note_type,
-            app_data_dynamic,
-            value,
-            nk_container,
-            is_merkle_checked: true,
-            psi: rseed.get_psi(&rho),
-            rcm: rseed.get_rcm(&rho),
-            rho,
-        }
-    }
-
-    pub fn dummy_zero_note<R: RngCore>(mut rng: R, rho: Nullifier) -> Self {
+    pub fn random_padding_input_note<R: RngCore>(mut rng: R) -> Self {
         let app_vk = *COMPRESSED_TRIVIAL_VP_VK;
         let app_data_static = pallas::Base::random(&mut rng);
         let note_type = NoteType::new(app_vk, app_data_static);
-        let app_data_dynamic = pallas::Base::zero();
-        let nk = NullifierKeyContainer::random_key(&mut rng);
+        let app_data_dynamic = pallas::Base::random(&mut rng);
+        let rho = Nullifier::new(pallas::Base::random(&mut rng));
+        let nk = NullifierKeyContainer::from_key(pallas::Base::random(&mut rng));
         let rseed = RandomSeed::random(&mut rng);
-        Self {
+        Note {
             note_type,
             app_data_dynamic,
             value: 0,
@@ -209,6 +171,24 @@ impl Note {
         }
     }
 
+    pub fn random_padding_output_note<R: RngCore>(mut rng: R, rho: Nullifier) -> Self {
+        let app_vk = *COMPRESSED_TRIVIAL_VP_VK;
+        let app_data_static = pallas::Base::random(&mut rng);
+        let note_type = NoteType::new(app_vk, app_data_static);
+        let app_data_dynamic = pallas::Base::random(&mut rng);
+        let nk_com = NullifierKeyContainer::from_commitment(pallas::Base::random(&mut rng));
+        let rseed = RandomSeed::random(&mut rng);
+        Note {
+            note_type,
+            app_data_dynamic,
+            value: 0,
+            nk_container: nk_com,
+            rho,
+            psi: rseed.get_psi(&rho),
+            rcm: rseed.get_rcm(&rho),
+            is_merkle_checked: false,
+        }
+    }
     // cm = SinsemillaCommit^rcm(address || app_vk || app_data_static || rho || psi || is_merkle_checked || value)
     pub fn commitment(&self) -> NoteCommitment {
         let address = self.get_address();
@@ -508,18 +488,6 @@ impl OutputNoteProvingInfo {
         }
     }
 
-    // TODO: move it to test mod
-    pub fn dummy<R: RngCore>(mut rng: R, nf: Nullifier) -> Self {
-        let note = Note::dummy_output(&mut rng, nf);
-        let app_vp_verifying_info = Box::new(TrivialValidityPredicateCircuit::dummy(&mut rng));
-        let app_vp_verifying_info_dynamic = vec![];
-        Self {
-            note,
-            app_vp_verifying_info,
-            app_vp_verifying_info_dynamic,
-        }
-    }
-
     pub fn get_app_vp_verifying_info(&self) -> Box<dyn ValidityPredicateVerifyingInfo> {
         self.app_vp_verifying_info.clone()
     }
@@ -544,26 +512,124 @@ impl OutputNoteProvingInfo {
     }
 }
 
-#[test]
-fn note_serialization_test() {
-    use rand::rngs::OsRng;
-    let mut rng = OsRng;
+#[cfg(test)]
+pub mod tests {
+    use super::{InputNoteProvingInfo, Note, NoteType, OutputNoteProvingInfo, RandomSeed};
+    use crate::{
+        circuit::vp_examples::{tests::random_trivial_vp_circuit, COMPRESSED_TRIVIAL_VP_VK},
+        merkle_tree::tests::random_merkle_path,
+        nullifier::{tests::*, Nullifier, NullifierKeyContainer},
+    };
+    use halo2_proofs::arithmetic::Field;
+    use pasta_curves::pallas;
+    use rand::{Rng, RngCore};
 
-    let input_note = Note::dummy(&mut rng);
-    {
-        // BorshSerialize
-        let borsh = input_note.try_to_vec().unwrap();
-        // BorshDeserialize
-        let de_note: Note = BorshDeserialize::deserialize(&mut borsh.as_ref()).unwrap();
-        assert_eq!(input_note, de_note);
+    pub fn random_note_type<R: RngCore>(mut rng: R) -> NoteType {
+        let app_vk = pallas::Base::random(&mut rng);
+        let app_data_static = pallas::Base::random(&mut rng);
+        NoteType::new(app_vk, app_data_static)
     }
 
-    let output_note = Note::dummy_output(&mut rng, input_note.rho);
-    {
-        // BorshSerialize
-        let borsh = output_note.try_to_vec().unwrap();
-        // BorshDeserialize
-        let de_note: Note = BorshDeserialize::deserialize(&mut borsh.as_ref()).unwrap();
-        assert_eq!(output_note, de_note);
+    pub fn random_input_note<R: RngCore>(mut rng: R) -> Note {
+        let rho = random_nullifier(&mut rng);
+        let nk = random_nullifier_key(&mut rng);
+        random_note_from_parts(&mut rng, rho, nk)
+    }
+
+    pub fn random_output_note<R: RngCore>(mut rng: R, rho: Nullifier) -> Note {
+        let nk_com = random_nullifier_key_commitment(&mut rng);
+        random_note_from_parts(&mut rng, rho, nk_com)
+    }
+
+    pub fn random_zero_note<R: RngCore>(mut rng: R, rho: Nullifier) -> Note {
+        let app_vk = *COMPRESSED_TRIVIAL_VP_VK;
+        let app_data_static = pallas::Base::random(&mut rng);
+        let note_type = NoteType::new(app_vk, app_data_static);
+        let app_data_dynamic = pallas::Base::random(&mut rng);
+        let nk = random_nullifier_key(&mut rng);
+        let rseed = RandomSeed::random(&mut rng);
+        Note {
+            note_type,
+            app_data_dynamic,
+            value: 0,
+            nk_container: nk,
+            rho,
+            psi: rseed.get_psi(&rho),
+            rcm: rseed.get_rcm(&rho),
+            is_merkle_checked: false,
+        }
+    }
+
+    fn random_note_from_parts<R: RngCore>(
+        mut rng: R,
+        rho: Nullifier,
+        nk_container: NullifierKeyContainer,
+    ) -> Note {
+        let note_type = random_note_type(&mut rng);
+        let app_data_dynamic = pallas::Base::random(&mut rng);
+        let value: u64 = rng.gen();
+        let rseed = RandomSeed::random(&mut rng);
+        Note {
+            note_type,
+            app_data_dynamic,
+            value,
+            nk_container,
+            is_merkle_checked: true,
+            psi: rseed.get_psi(&rho),
+            rcm: rseed.get_rcm(&rho),
+            rho,
+        }
+    }
+
+    pub fn random_input_proving_info<R: RngCore>(mut rng: R) -> InputNoteProvingInfo {
+        let note = random_input_note(&mut rng);
+        let auth_path = random_merkle_path(&mut rng);
+        let app_vp_verifying_info = Box::new(random_trivial_vp_circuit(&mut rng));
+        let app_vp_verifying_info_dynamic = vec![];
+        InputNoteProvingInfo::new(
+            note,
+            auth_path,
+            app_vp_verifying_info,
+            app_vp_verifying_info_dynamic,
+        )
+    }
+
+    pub fn random_output_proving_info<R: RngCore>(
+        mut rng: R,
+        rho: Nullifier,
+    ) -> OutputNoteProvingInfo {
+        let note = random_output_note(&mut rng, rho);
+        let app_vp_verifying_info = Box::new(random_trivial_vp_circuit(&mut rng));
+        let app_vp_verifying_info_dynamic = vec![];
+        OutputNoteProvingInfo {
+            note,
+            app_vp_verifying_info,
+            app_vp_verifying_info_dynamic,
+        }
+    }
+
+    #[test]
+    fn note_serialization_test() {
+        use borsh::{BorshDeserialize, BorshSerialize};
+        use rand::rngs::OsRng;
+        let mut rng = OsRng;
+
+        let input_note = random_input_note(&mut rng);
+        {
+            // BorshSerialize
+            let borsh = input_note.try_to_vec().unwrap();
+            // BorshDeserialize
+            let de_note: Note = BorshDeserialize::deserialize(&mut borsh.as_ref()).unwrap();
+            assert_eq!(input_note, de_note);
+        }
+
+        let output_note = random_output_note(&mut rng, input_note.rho);
+        {
+            // BorshSerialize
+            let borsh = output_note.try_to_vec().unwrap();
+            // BorshDeserialize
+            let de_note: Note = BorshDeserialize::deserialize(&mut borsh.as_ref()).unwrap();
+            assert_eq!(output_note, de_note);
+        }
     }
 }

--- a/taiga_halo2/src/note.rs
+++ b/taiga_halo2/src/note.rs
@@ -74,12 +74,18 @@ pub struct Note {
 }
 
 /// The parameters in the NoteType are used to derive note type.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, Eq)]
 pub struct NoteType {
     /// app_vk is the compressed verifying key of VP
     pub app_vk: pallas::Base,
     /// app_data_static is the encoded data that is defined in application vp
     pub app_data_static: pallas::Base,
+}
+
+impl PartialEq for NoteType {
+    fn eq(&self, other: &Self) -> bool {
+        self.app_vk == other.app_vk && self.app_data_static == other.app_data_static
+    }
 }
 
 #[derive(Copy, Clone, Debug, Default)]
@@ -516,7 +522,7 @@ impl OutputNoteProvingInfo {
 pub mod tests {
     use super::{InputNoteProvingInfo, Note, NoteType, OutputNoteProvingInfo, RandomSeed};
     use crate::{
-        circuit::vp_examples::{tests::random_trivial_vp_circuit, COMPRESSED_TRIVIAL_VP_VK},
+        circuit::vp_examples::tests::random_trivial_vp_circuit,
         merkle_tree::tests::random_merkle_path,
         nullifier::{tests::*, Nullifier, NullifierKeyContainer},
     };
@@ -539,25 +545,6 @@ pub mod tests {
     pub fn random_output_note<R: RngCore>(mut rng: R, rho: Nullifier) -> Note {
         let nk_com = random_nullifier_key_commitment(&mut rng);
         random_note_from_parts(&mut rng, rho, nk_com)
-    }
-
-    pub fn random_zero_note<R: RngCore>(mut rng: R, rho: Nullifier) -> Note {
-        let app_vk = *COMPRESSED_TRIVIAL_VP_VK;
-        let app_data_static = pallas::Base::random(&mut rng);
-        let note_type = NoteType::new(app_vk, app_data_static);
-        let app_data_dynamic = pallas::Base::random(&mut rng);
-        let nk = random_nullifier_key(&mut rng);
-        let rseed = RandomSeed::random(&mut rng);
-        Note {
-            note_type,
-            app_data_dynamic,
-            value: 0,
-            nk_container: nk,
-            rho,
-            psi: rseed.get_psi(&rho),
-            rcm: rseed.get_rcm(&rho),
-            is_merkle_checked: false,
-        }
     }
 
     fn random_note_from_parts<R: RngCore>(

--- a/taiga_halo2/src/note.rs
+++ b/taiga_halo2/src/note.rs
@@ -5,9 +5,9 @@ use crate::{
     },
     constant::{
         BASE_BITS_NUM, NOTE_COMMIT_DOMAIN, NUM_NOTE, POSEIDON_TO_CURVE_INPUT_LEN,
-        PRF_EXPAND_PERSONALIZATION, PRF_EXPAND_PSI, PRF_EXPAND_RCM, TAIGA_COMMITMENT_TREE_DEPTH,
+        PRF_EXPAND_PERSONALIZATION, PRF_EXPAND_PSI, PRF_EXPAND_RCM,
     },
-    merkle_tree::{MerklePath, Node, LR},
+    merkle_tree::MerklePath,
     nullifier::{Nullifier, NullifierKeyContainer},
     utils::{extract_p, mod_r_p, poseidon_hash, poseidon_to_curve},
 };
@@ -94,8 +94,7 @@ pub struct RandomSeed([u8; 32]);
 #[derive(Clone)]
 pub struct InputNoteProvingInfo {
     pub note: Note,
-    pub auth_path: [(pallas::Base, LR); TAIGA_COMMITMENT_TREE_DEPTH],
-    pub root: pallas::Base,
+    pub merkle_path: MerklePath,
     app_vp_verifying_info: Box<dyn ValidityPredicateVerifyingInfo>,
     app_vp_verifying_info_dynamic: Vec<Box<dyn ValidityPredicateVerifyingInfo>>,
 }
@@ -443,14 +442,9 @@ impl InputNoteProvingInfo {
         app_vp_verifying_info: Box<dyn ValidityPredicateVerifyingInfo>,
         app_vp_verifying_info_dynamic: Vec<Box<dyn ValidityPredicateVerifyingInfo>>,
     ) -> Self {
-        let cm_node = Node::new(note.commitment().get_x());
-        let root = merkle_path.root(cm_node).inner();
-        let auth_path: [(pallas::Base, LR); TAIGA_COMMITMENT_TREE_DEPTH] =
-            merkle_path.get_path().try_into().unwrap();
         Self {
             note,
-            auth_path,
-            root,
+            merkle_path,
             app_vp_verifying_info,
             app_vp_verifying_info_dynamic,
         }
@@ -570,12 +564,12 @@ pub mod tests {
 
     pub fn random_input_proving_info<R: RngCore>(mut rng: R) -> InputNoteProvingInfo {
         let note = random_input_note(&mut rng);
-        let auth_path = random_merkle_path(&mut rng);
+        let merkle_path = random_merkle_path(&mut rng);
         let app_vp_verifying_info = Box::new(random_trivial_vp_circuit(&mut rng));
         let app_vp_verifying_info_dynamic = vec![];
         InputNoteProvingInfo::new(
             note,
-            auth_path,
+            merkle_path,
             app_vp_verifying_info,
             app_vp_verifying_info_dynamic,
         )

--- a/taiga_halo2/src/nullifier.rs
+++ b/taiga_halo2/src/nullifier.rs
@@ -120,3 +120,24 @@ impl Default for NullifierKeyContainer {
         NullifierKeyContainer::from_key(key)
     }
 }
+
+#[cfg(test)]
+pub mod tests {
+    use halo2_proofs::arithmetic::Field;
+    use pasta_curves::pallas;
+    use rand::RngCore;
+
+    use super::{Nullifier, NullifierKeyContainer};
+
+    pub fn random_nullifier<R: RngCore>(mut rng: R) -> Nullifier {
+        Nullifier::new(pallas::Base::random(&mut rng))
+    }
+
+    pub fn random_nullifier_key<R: RngCore>(mut rng: R) -> NullifierKeyContainer {
+        NullifierKeyContainer::from_key(pallas::Base::random(&mut rng))
+    }
+
+    pub fn random_nullifier_key_commitment<R: RngCore>(mut rng: R) -> NullifierKeyContainer {
+        NullifierKeyContainer::from_commitment(pallas::Base::random(&mut rng))
+    }
+}

--- a/taiga_halo2/src/shielded_ptx.rs
+++ b/taiga_halo2/src/shielded_ptx.rs
@@ -65,7 +65,7 @@ impl ShieldedPartialTransaction {
             .into_iter()
             .zip(output_info.into_iter())
             .map(|(input, output)| {
-                let action_info = ActionInfo::new(input, output, &mut rng);
+                let action_info = ActionInfo::from_proving_info(input, output, &mut rng);
                 rcv_sum += action_info.get_rcv();
                 ActionVerifyingInfo::create(action_info, &mut rng).unwrap()
             })

--- a/taiga_halo2/src/shielded_ptx.rs
+++ b/taiga_halo2/src/shielded_ptx.rs
@@ -63,7 +63,7 @@ impl ShieldedPartialTransaction {
         let mut rcv_sum = pallas::Scalar::zero();
         let actions: Vec<ActionVerifyingInfo> = input_info
             .into_iter()
-            .zip(output_info.into_iter())
+            .zip(output_info)
             .map(|(input, output)| {
                 let action_info = ActionInfo::from_proving_info(input, output, &mut rng);
                 rcv_sum += action_info.get_rcv();
@@ -352,7 +352,7 @@ pub mod testing {
         let input_note_1 = {
             let app_data_static = pallas::Base::zero();
             // TODO: add real application dynamic VPs and encode them to app_data_dynamic later.
-            let app_dynamic_vp_vk = vec![compressed_trivial_vp_vk, compressed_trivial_vp_vk];
+            let app_dynamic_vp_vk = [compressed_trivial_vp_vk, compressed_trivial_vp_vk];
             // Encode the app_dynamic_vp_vk into app_data_dynamic
             // The encoding method is flexible and defined in the application vp.
             // Use poseidon hash to encode the two dynamic VPs here

--- a/taiga_halo2/src/shielded_ptx.rs
+++ b/taiga_halo2/src/shielded_ptx.rs
@@ -325,12 +325,12 @@ impl NoteVPVerifyingInfoSet {
     }
 }
 
+#[cfg(test)]
 pub mod testing {
     use crate::{
         circuit::vp_circuit::ValidityPredicateVerifyingInfo,
         circuit::vp_examples::TrivialValidityPredicateCircuit,
-        constant::TAIGA_COMMITMENT_TREE_DEPTH,
-        merkle_tree::MerklePath,
+        merkle_tree::tests::random_merkle_path,
         note::{InputNoteProvingInfo, Note, OutputNoteProvingInfo, RandomSeed},
         nullifier::{Nullifier, NullifierKeyContainer},
         shielded_ptx::ShieldedPartialTransaction,
@@ -435,7 +435,7 @@ pub mod testing {
         };
 
         // Generate note info
-        let merkle_path = MerklePath::dummy(&mut rng, TAIGA_COMMITMENT_TREE_DEPTH);
+        let merkle_path = random_merkle_path(&mut rng);
         // Create vp circuit and fill the note info
         let mut trivial_vp_circuit = TrivialValidityPredicateCircuit {
             owned_note_pub_id: input_note_1.get_nf().unwrap().inner(),

--- a/taiga_halo2/src/transaction.rs
+++ b/taiga_halo2/src/transaction.rs
@@ -317,6 +317,7 @@ impl TransparentPartialTxBundle {
     }
 }
 
+#[cfg(test)]
 pub mod testing {
     use crate::shielded_ptx::testing::create_shielded_ptx;
     use crate::transaction::ShieldedPartialTxBundle;
@@ -334,29 +335,30 @@ pub mod testing {
         });
         (bundle, r_vec)
     }
-}
 
-#[test]
-fn test_halo2_transaction() {
-    use crate::transaction::testing::create_shielded_ptx_bundle;
-    use rand::rngs::OsRng;
+    #[test]
+    fn test_halo2_transaction() {
+        use super::Transaction;
+        use borsh::{BorshDeserialize, BorshSerialize};
+        use rand::rngs::OsRng;
 
-    let rng = OsRng;
+        let rng = OsRng;
 
-    // Create shielded partial tx bundle
-    let (shielded_ptx_bundle, r_vec) = create_shielded_ptx_bundle(2);
-    // TODO: add transparent_ptx_bundle test
-    let transparent_ptx_bundle = None;
-    let tx = Transaction::build(
-        rng,
-        Some(shielded_ptx_bundle),
-        transparent_ptx_bundle,
-        r_vec,
-    );
-    let (shielded_ret, _) = tx.execute().unwrap();
+        // Create shielded partial tx bundle
+        let (shielded_ptx_bundle, r_vec) = create_shielded_ptx_bundle(2);
+        // TODO: add transparent_ptx_bundle test
+        let transparent_ptx_bundle = None;
+        let tx = Transaction::build(
+            rng,
+            Some(shielded_ptx_bundle),
+            transparent_ptx_bundle,
+            r_vec,
+        );
+        let (shielded_ret, _) = tx.execute().unwrap();
 
-    let borsh = tx.try_to_vec().unwrap();
-    let de_tx: Transaction = BorshDeserialize::deserialize(&mut borsh.as_ref()).unwrap();
-    let (de_shielded_ret, _) = de_tx.execute().unwrap();
-    assert_eq!(shielded_ret, de_shielded_ret);
+        let borsh = tx.try_to_vec().unwrap();
+        let de_tx: Transaction = BorshDeserialize::deserialize(&mut borsh.as_ref()).unwrap();
+        let (de_shielded_ret, _) = de_tx.execute().unwrap();
+        assert_eq!(shielded_ret, de_shielded_ret);
+    }
 }

--- a/taiga_halo2/src/transaction.rs
+++ b/taiga_halo2/src/transaction.rs
@@ -328,11 +328,11 @@ pub mod testing {
     ) -> (ShieldedPartialTxBundle, Vec<pallas::Scalar>) {
         let mut bundle = ShieldedPartialTxBundle::new();
         let mut r_vec = vec![];
-        [0..num].iter().for_each(|_| {
+        for _ in 0..num {
             let (ptx, r) = create_shielded_ptx();
             bundle.add_partial_tx(ptx);
             r_vec.push(r);
-        });
+        }
         (bundle, r_vec)
     }
 

--- a/taiga_halo2/src/vp_vk.rs
+++ b/taiga_halo2/src/vp_vk.rs
@@ -19,7 +19,7 @@ impl ValidityPredicateVerifyingKey {
         Self::Uncompressed(vk)
     }
 
-    pub fn from_compressed(vk: pallas::Base)  -> Self {
+    pub fn from_compressed(vk: pallas::Base) -> Self {
         Self::Compressed(vk)
     }
 

--- a/taiga_halo2/src/vp_vk.rs
+++ b/taiga_halo2/src/vp_vk.rs
@@ -75,7 +75,7 @@ impl Eq for ValidityPredicateVerifyingKey {}
 
 #[test]
 fn test_vpd_hashing() {
-    use crate::circuit::vp_examples::TrivialValidityPredicateCircuit;
+    use crate::circuit::vp_examples::tests::random_trivial_vp_circuit;
     use halo2_proofs::plonk;
     use rand::rngs::OsRng;
     use std::{collections::hash_map::DefaultHasher, hash::Hasher};
@@ -86,9 +86,9 @@ fn test_vpd_hashing() {
         s.finish()
     }
 
-    let circuit1 = TrivialValidityPredicateCircuit::dummy(&mut OsRng);
-    let circuit2 = TrivialValidityPredicateCircuit::dummy(&mut OsRng);
-    let circuit3 = TrivialValidityPredicateCircuit::dummy(&mut OsRng);
+    let circuit1 = random_trivial_vp_circuit(&mut OsRng);
+    let circuit2 = random_trivial_vp_circuit(&mut OsRng);
+    let circuit3 = random_trivial_vp_circuit(&mut OsRng);
 
     let params1 = halo2_proofs::poly::commitment::Params::new(12);
     let vk1 = plonk::keygen_vk(&params1, &circuit1).unwrap();

--- a/taiga_halo2/src/vp_vk.rs
+++ b/taiga_halo2/src/vp_vk.rs
@@ -1,10 +1,9 @@
 use blake2b_simd::Params as Blake2bParams;
-use halo2_proofs::{arithmetic::Field, plonk::VerifyingKey};
+use halo2_proofs::plonk::VerifyingKey;
 use pasta_curves::{
     group::ff::{FromUniformBytes, PrimeField},
     pallas, vesta,
 };
-use rand::RngCore;
 use std::hash::Hash;
 
 #[derive(Debug, Clone)]
@@ -18,6 +17,10 @@ pub enum ValidityPredicateVerifyingKey {
 impl ValidityPredicateVerifyingKey {
     pub fn from_vk(vk: VerifyingKey<vesta::Affine>) -> Self {
         Self::Uncompressed(vk)
+    }
+
+    pub fn from_compressed(vk: pallas::Base)  -> Self {
+        Self::Compressed(vk)
     }
 
     pub fn get_vk(&self) -> Option<VerifyingKey<vesta::Affine>> {
@@ -45,10 +48,6 @@ impl ValidityPredicateVerifyingKey {
             }
             ValidityPredicateVerifyingKey::Compressed(v) => *v,
         }
-    }
-
-    pub fn dummy(rng: &mut impl RngCore) -> Self {
-        Self::Compressed(pallas::Base::random(rng))
     }
 }
 


### PR DESCRIPTION
- Move the `dummy/random` APIs to the tests mod, which are only used in the tests.
- Add `random_padding_input/output_note` APIs for the `Note`.
- Remove the unused VP-related parameters from the `ActionInfo` struct.
- `auth_path` and `merkle_path` were both used. Unify the name to `merkle_path`.