### PR TITLE
BEAM Integration

### DIFF
--- a/taiga_halo2/Cargo.toml
+++ b/taiga_halo2/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-rustler = "0.29.1"
+rustler = {version = "0.29.1", optional = true}
 rand = "0.8.4"
 lazy_static = "1"
 blake2b_simd = "1"
@@ -26,6 +26,10 @@ num-bigint = "0.4.3"
 [dev-dependencies]
 criterion = "0.5.1"
 proptest = "1.0.0"
+
+[features]
+default = []
+nif = ["rustler", "pasta_curves/repr-erlang"]
 
 [[bench]]
 name = "action_proof"

--- a/taiga_halo2/Cargo.toml
+++ b/taiga_halo2/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+rustler = "0.29.1"
 rand = "0.8.4"
 lazy_static = "1"
 blake2b_simd = "1"

--- a/taiga_halo2/Cargo.toml
+++ b/taiga_halo2/Cargo.toml
@@ -8,7 +8,7 @@ rustler = "0.29.1"
 rand = "0.8.4"
 lazy_static = "1"
 blake2b_simd = "1"
-pasta_curves = "0.5.1"
+pasta_curves = {version = "0.5.1", features = ["repr-erlang"]}
 ff = "0.13"
 group = "0.13"
 halo2_gadgets = {version = "0.3", features = ["test-dependencies"]}

--- a/taiga_halo2/src/action.rs
+++ b/taiga_halo2/src/action.rs
@@ -10,12 +10,14 @@ use ff::PrimeField;
 use halo2_proofs::arithmetic::Field;
 use pasta_curves::pallas;
 use rand::RngCore;
+#[cfg(feature = "nif")]
 use rustler::NifStruct;
 use std::io;
 
 /// The action result used in transaction.
-#[derive(Copy, Debug, Clone, NifStruct)]
-#[module = "Taiga.Action.Instance"]
+#[derive(Copy, Debug, Clone)]
+#[cfg_attr(feature = "nif", derive(NifStruct))]
+#[cfg_attr(feature = "nif", module = "Taiga.Action.Instance")]
 pub struct ActionInstance {
     /// The root of the note commitment Merkle tree.
     pub anchor: pallas::Base,

--- a/taiga_halo2/src/action.rs
+++ b/taiga_halo2/src/action.rs
@@ -10,10 +10,12 @@ use ff::PrimeField;
 use halo2_proofs::arithmetic::Field;
 use pasta_curves::pallas;
 use rand::RngCore;
+use rustler::NifStruct;
 use std::io;
 
 /// The action result used in transaction.
-#[derive(Copy, Debug, Clone)]
+#[derive(Copy, Debug, Clone, NifStruct)]
+#[module = "Taiga.Action.Instance"]
 pub struct ActionInstance {
     /// The root of the note commitment Merkle tree.
     pub anchor: pallas::Base,

--- a/taiga_halo2/src/circuit/vp_circuit.rs
+++ b/taiga_halo2/src/circuit/vp_circuit.rs
@@ -56,7 +56,9 @@ use vamp_ir::halo2::synth::{make_constant, Halo2Module, PrimeFieldOps};
 use vamp_ir::transform::compile;
 use vamp_ir::util::{read_inputs_from_file, Config};
 
+#[cfg(feature = "nif")]
 use rustler::types::atom;
+#[cfg(feature = "nif")]
 use rustler::{Decoder, Encoder, Env, NifResult, Term};
 
 #[derive(Debug, Clone)]
@@ -66,8 +68,10 @@ pub struct VPVerifyingInfo {
     pub public_inputs: ValidityPredicatePublicInputs,
 }
 
+#[cfg(feature = "nif")]
 rustler::atoms! {verifying_info}
 
+#[cfg(feature = "nif")]
 impl Encoder for VPVerifyingInfo {
     fn encode<'a>(&self, env: Env<'a>) -> Term<'a> {
         (
@@ -80,6 +84,7 @@ impl Encoder for VPVerifyingInfo {
     }
 }
 
+#[cfg(feature = "nif")]
 impl<'a> Decoder<'a> for VPVerifyingInfo {
     fn decode(term: Term<'a>) -> NifResult<Self> {
         let (term, vk, proof, public_inputs): (
@@ -107,12 +112,14 @@ impl<'a> Decoder<'a> for VPVerifyingInfo {
 #[derive(Clone, Debug)]
 pub struct ValidityPredicatePublicInputs([pallas::Base; VP_CIRCUIT_PUBLIC_INPUT_NUM]);
 
+#[cfg(feature = "nif")]
 impl Encoder for ValidityPredicatePublicInputs {
     fn encode<'a>(&self, env: Env<'a>) -> Term<'a> {
         self.0.to_vec().encode(env)
     }
 }
 
+#[cfg(feature = "nif")]
 impl<'a> Decoder<'a> for ValidityPredicatePublicInputs {
     fn decode(term: Term<'a>) -> NifResult<Self> {
         let val: Vec<pallas::Base> = Decoder::decode(term)?;

--- a/taiga_halo2/src/circuit/vp_examples.rs
+++ b/taiga_halo2/src/circuit/vp_examples.rs
@@ -17,6 +17,7 @@ use halo2_proofs::{
 use lazy_static::lazy_static;
 use pasta_curves::pallas;
 use rand::{rngs::OsRng, RngCore};
+#[cfg(feature = "nif")]
 use rustler::{Decoder, Encoder, Env, NifResult, NifStruct, Term};
 
 pub mod cascade_intent;
@@ -42,8 +43,9 @@ pub struct TrivialValidityPredicateCircuit {
 }
 
 // I only exist to allow trivial derivation of the nifstruct
-#[derive(Clone, Debug, Default, NifStruct)]
-#[module = "Taiga.VP.Trivial"]
+#[derive(Clone, Debug, Default)]
+#[cfg_attr(feature = "nif", derive(NifStruct))]
+#[cfg_attr(feature = "nif", module = "Taiga.VP.Trivial")]
 struct TrivialValidtyPredicateCircuitProxy {
     owned_note_pub_id: pallas::Base,
     input_notes: Vec<Note>,
@@ -84,11 +86,13 @@ impl TrivialValidtyPredicateCircuitProxy {
         })
     }
 }
+#[cfg(feature = "nif")]
 impl Encoder for TrivialValidityPredicateCircuit {
     fn encode<'a>(&self, env: Env<'a>) -> Term<'a> {
         self.to_proxy().encode(env)
     }
 }
+#[cfg(feature = "nif")]
 impl<'a> Decoder<'a> for TrivialValidityPredicateCircuit {
     fn decode(term: Term<'a>) -> NifResult<Self> {
         let val: TrivialValidtyPredicateCircuitProxy = Decoder::decode(term)?;

--- a/taiga_halo2/src/note.rs
+++ b/taiga_halo2/src/note.rs
@@ -24,6 +24,7 @@ use pasta_curves::{
     pallas,
 };
 use rand::RngCore;
+#[cfg(feature = "nif")]
 use rustler::{NifStruct, NifTuple};
 use std::{
     hash::{Hash, Hasher},
@@ -31,7 +32,8 @@ use std::{
 };
 
 /// A commitment to a note.
-#[derive(Copy, Debug, Clone, NifTuple)]
+#[derive(Copy, Debug, Clone)]
+#[cfg_attr(feature = "nif", derive(NifTuple))]
 pub struct NoteCommitment(pallas::Point);
 
 impl NoteCommitment {
@@ -55,8 +57,9 @@ impl Default for NoteCommitment {
 }
 
 /// A note
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, NifStruct)]
-#[module = "Taiga.Note"]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "nif", derive(NifStruct))]
+#[cfg_attr(feature = "nif", module = "Taiga.Note")]
 pub struct Note {
     pub note_type: NoteType,
     /// app_data_dynamic is the data defined in application vp and will NOT be used to derive type
@@ -77,8 +80,9 @@ pub struct Note {
 }
 
 /// The parameters in the NoteType are used to derive note type.
-#[derive(Debug, Clone, Copy, Default, Eq, NifStruct)]
-#[module = "Taiga.NoteType"]
+#[derive(Debug, Clone, Copy, Default, Eq)]
+#[cfg_attr(feature = "nif", derive(NifStruct))]
+#[cfg_attr(feature = "nif", module = "Taiga.NoteType")]
 pub struct NoteType {
     /// app_vk is the compressed verifying key of VP
     pub app_vk: pallas::Base,

--- a/taiga_halo2/src/note.rs
+++ b/taiga_halo2/src/note.rs
@@ -24,13 +24,14 @@ use pasta_curves::{
     pallas,
 };
 use rand::RngCore;
+use rustler::{NifStruct, NifTuple};
 use std::{
     hash::{Hash, Hasher},
     io,
 };
 
 /// A commitment to a note.
-#[derive(Copy, Debug, Clone)]
+#[derive(Copy, Debug, Clone, NifTuple)]
 pub struct NoteCommitment(pallas::Point);
 
 impl NoteCommitment {
@@ -54,7 +55,8 @@ impl Default for NoteCommitment {
 }
 
 /// A note
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, NifStruct)]
+#[module = "Taiga.Note"]
 pub struct Note {
     pub note_type: NoteType,
     /// app_data_dynamic is the data defined in application vp and will NOT be used to derive type
@@ -75,7 +77,8 @@ pub struct Note {
 }
 
 /// The parameters in the NoteType are used to derive note type.
-#[derive(Debug, Clone, Copy, Default, Eq)]
+#[derive(Debug, Clone, Copy, Default, Eq, NifStruct)]
+#[module = "Taiga.NoteType"]
 pub struct NoteType {
     /// app_vk is the compressed verifying key of VP
     pub app_vk: pallas::Base,

--- a/taiga_halo2/src/nullifier.rs
+++ b/taiga_halo2/src/nullifier.rs
@@ -8,15 +8,18 @@ use pasta_curves::group::cofactor::CofactorCurveAffine;
 use pasta_curves::group::ff::PrimeField;
 use pasta_curves::pallas;
 use rand::RngCore;
+#[cfg(feature = "nif")]
 use rustler::{NifTaggedEnum, NifTuple};
 use subtle::CtOption;
 
 /// The unique nullifier.
-#[derive(Copy, Debug, Clone, PartialEq, Eq, NifTuple)]
+#[derive(Copy, Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "nif", derive(NifTuple))]
 pub struct Nullifier(pallas::Base);
 
 /// The NullifierKeyContainer contains the nullifier_key or the nullifier_key commitment
-#[derive(Copy, Debug, Clone, PartialEq, Eq, NifTaggedEnum)]
+#[derive(Copy, Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "nif", derive(NifTaggedEnum))]
 pub enum NullifierKeyContainer {
     // The NullifierKeyContainer::Commitment is the commitment of NullifierKeyContainer::Key `nk_com = Commitment(nk, 0)`
     Commitment(pallas::Base),

--- a/taiga_halo2/src/nullifier.rs
+++ b/taiga_halo2/src/nullifier.rs
@@ -8,14 +8,15 @@ use pasta_curves::group::cofactor::CofactorCurveAffine;
 use pasta_curves::group::ff::PrimeField;
 use pasta_curves::pallas;
 use rand::RngCore;
+use rustler::{NifTaggedEnum, NifTuple};
 use subtle::CtOption;
 
 /// The unique nullifier.
-#[derive(Copy, Debug, Clone, PartialEq, Eq)]
+#[derive(Copy, Debug, Clone, PartialEq, Eq, NifTuple)]
 pub struct Nullifier(pallas::Base);
 
 /// The NullifierKeyContainer contains the nullifier_key or the nullifier_key commitment
-#[derive(Copy, Debug, Clone, PartialEq, Eq)]
+#[derive(Copy, Debug, Clone, PartialEq, Eq, NifTaggedEnum)]
 pub enum NullifierKeyContainer {
     // The NullifierKeyContainer::Commitment is the commitment of NullifierKeyContainer::Key `nk_com = Commitment(nk, 0)`
     Commitment(pallas::Base),

--- a/taiga_halo2/src/proof.rs
+++ b/taiga_halo2/src/proof.rs
@@ -6,9 +6,11 @@ use halo2_proofs::{
 };
 use pasta_curves::{pallas, vesta};
 use rand::RngCore;
+#[cfg(feature = "nif")]
 use rustler::NifTuple;
 
-#[derive(Clone, Debug, BorshSerialize, BorshDeserialize, NifTuple)]
+#[derive(Clone, Debug, BorshSerialize, BorshDeserialize)]
+#[cfg_attr(feature = "nif", derive(NifTuple))]
 pub struct Proof(Vec<u8>);
 
 impl Proof {

--- a/taiga_halo2/src/proof.rs
+++ b/taiga_halo2/src/proof.rs
@@ -6,8 +6,9 @@ use halo2_proofs::{
 };
 use pasta_curves::{pallas, vesta};
 use rand::RngCore;
+use rustler::NifTuple;
 
-#[derive(Clone, Debug, BorshSerialize, BorshDeserialize)]
+#[derive(Clone, Debug, BorshSerialize, BorshDeserialize, NifTuple)]
 pub struct Proof(Vec<u8>);
 
 impl Proof {

--- a/taiga_halo2/src/shielded_ptx.rs
+++ b/taiga_halo2/src/shielded_ptx.rs
@@ -14,7 +14,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use halo2_proofs::plonk::Error;
 use pasta_curves::pallas;
 use rand::RngCore;
-use rustler::NifStruct;
+use rustler::{Decoder, Encoder, Env, NifResult, NifStruct, Term};
 
 #[derive(Debug, Clone)]
 pub struct ShieldedPartialTransaction {
@@ -37,6 +37,15 @@ pub struct NoteVPVerifyingInfoSet {
     app_dynamic_vp_verifying_info: Vec<VPVerifyingInfo>,
     // TODO: add verifier proof and according public inputs.
     // When the verifier proof is added, we may need to reconsider the structure of `VPVerifyingInfo`
+}
+
+// Is easier to derive traits for
+#[derive(Debug, Clone, NifStruct)]
+#[module = "Taiga.Shielded.PTX"]
+struct ShieldedPartialTransactionProxy {
+    actions: Vec<ActionVerifyingInfo>,
+    inputs: Vec<NoteVPVerifyingInfoSet>,
+    outputs: Vec<NoteVPVerifyingInfoSet>,
 }
 
 impl ShieldedPartialTransaction {
@@ -166,6 +175,28 @@ impl ShieldedPartialTransaction {
         }
         Ok(())
     }
+
+    // Conversion to the generic length proxy
+    fn to_proxy(&self) -> ShieldedPartialTransactionProxy {
+        ShieldedPartialTransactionProxy {
+            actions: self.actions.to_vec(),
+            inputs: self.inputs.to_vec(),
+            outputs: self.outputs.to_vec(),
+        }
+    }
+}
+
+impl ShieldedPartialTransactionProxy {
+    fn to_concrete(&self) -> Option<ShieldedPartialTransaction> {
+        let actions = self.actions.clone().try_into().ok()?;
+        let inputs = self.inputs.clone().try_into().ok()?;
+        let outputs = self.outputs.clone().try_into().ok()?;
+        Some(ShieldedPartialTransaction {
+            actions,
+            inputs,
+            outputs,
+        })
+    }
 }
 
 impl Executable for ShieldedPartialTransaction {
@@ -241,6 +272,19 @@ impl BorshDeserialize for ShieldedPartialTransaction {
         })
     }
 }
+impl Encoder for ShieldedPartialTransaction {
+    fn encode<'a>(&self, env: Env<'a>) -> Term<'a> {
+        self.to_proxy().encode(env)
+    }
+}
+impl<'a> Decoder<'a> for ShieldedPartialTransaction {
+    fn decode(term: Term<'a>) -> NifResult<Self> {
+        let val: ShieldedPartialTransactionProxy = Decoder::decode(term)?;
+        val.to_concrete()
+            .ok_or(rustler::Error::RaiseAtom("Could not decode proxy"))
+    }
+}
+
 impl ActionVerifyingInfo {
     pub fn create<R: RngCore>(action_info: ActionInfo, mut rng: R) -> Result<Self, Error> {
         let (action_instance, circuit) = action_info.build();

--- a/taiga_halo2/src/shielded_ptx.rs
+++ b/taiga_halo2/src/shielded_ptx.rs
@@ -14,6 +14,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use halo2_proofs::plonk::Error;
 use pasta_curves::pallas;
 use rand::RngCore;
+use rustler::NifStruct;
 
 #[derive(Debug, Clone)]
 pub struct ShieldedPartialTransaction {
@@ -22,13 +23,15 @@ pub struct ShieldedPartialTransaction {
     outputs: [NoteVPVerifyingInfoSet; NUM_NOTE],
 }
 
-#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize, NifStruct)]
+#[module = "Taiga.Action.VerifyingInfo"]
 pub struct ActionVerifyingInfo {
     action_proof: Proof,
     action_instance: ActionInstance,
 }
 
-#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize, NifStruct)]
+#[module = "Taiga.Note.VerifyingInfo"]
 pub struct NoteVPVerifyingInfoSet {
     app_vp_verifying_info: VPVerifyingInfo,
     app_dynamic_vp_verifying_info: Vec<VPVerifyingInfo>,

--- a/taiga_halo2/src/transaction.rs
+++ b/taiga_halo2/src/transaction.rs
@@ -13,6 +13,7 @@ use pasta_curves::{
     pallas,
 };
 use rand::{CryptoRng, RngCore};
+use rustler::NifStruct;
 
 #[derive(Debug, Clone, BorshDeserialize, BorshSerialize)]
 pub struct Transaction {
@@ -34,7 +35,8 @@ pub struct ShieldedPartialTxBundle {
     partial_txs: Vec<ShieldedPartialTransaction>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, NifStruct)]
+#[module = "Taiga.Transaction.Result"]
 pub struct ShieldedResult {
     anchors: Vec<pallas::Base>,
     nullifiers: Vec<Nullifier>,

--- a/taiga_halo2/src/transaction.rs
+++ b/taiga_halo2/src/transaction.rs
@@ -13,7 +13,9 @@ use pasta_curves::{
     pallas,
 };
 use rand::{CryptoRng, RngCore};
+#[cfg(feature = "nif")]
 use rustler::types::atom;
+#[cfg(feature = "nif")]
 use rustler::{atoms, Decoder, Env, NifRecord, NifResult, NifStruct, Term};
 
 #[derive(Debug, Clone, BorshDeserialize, BorshSerialize)]
@@ -31,14 +33,16 @@ pub enum InProgressBindingSignature {
     Unauthorized(BindingSigningKey),
 }
 
-#[derive(Debug, Clone, BorshDeserialize, BorshSerialize, NifRecord)]
-#[tag = "bundle"]
+#[derive(Debug, Clone, BorshDeserialize, BorshSerialize)]
+#[cfg_attr(feature = "nif", derive(NifRecord))]
+#[cfg_attr(feature = "nif", tag = "bundle")]
 pub struct ShieldedPartialTxBundle {
     partial_txs: Vec<ShieldedPartialTransaction>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, NifStruct)]
-#[module = "Taiga.Transaction.Result"]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "nif", derive(NifStruct))]
+#[cfg_attr(feature = "nif", module = "Taiga.Transaction.Result")]
 pub struct ShieldedResult {
     anchors: Vec<pallas::Base>,
     nullifiers: Vec<Nullifier>,
@@ -202,8 +206,10 @@ impl Transaction {
     }
 }
 
+#[cfg(feature = "nif")]
 atoms! { transaction }
 
+#[cfg(feature = "nif")]
 impl rustler::Encoder for Transaction {
     fn encode<'a>(&self, env: Env<'a>) -> Term<'a> {
         (
@@ -219,6 +225,7 @@ impl rustler::Encoder for Transaction {
     }
 }
 
+#[cfg(feature = "nif")]
 impl<'a> Decoder<'a> for Transaction {
     fn decode(term: Term<'a>) -> NifResult<Self> {
         let (term, shielded_ptx_bundle, transparent_bytes, sig_bytes): (

--- a/taiga_halo2/src/value_commitment.rs
+++ b/taiga_halo2/src/value_commitment.rs
@@ -4,9 +4,10 @@ use halo2_proofs::arithmetic::CurveAffine;
 use pasta_curves::group::cofactor::CofactorCurveAffine;
 use pasta_curves::group::{Curve, Group, GroupEncoding};
 use pasta_curves::pallas;
+use rustler::NifTuple;
 use subtle::CtOption;
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, NifTuple)]
 pub struct ValueCommitment(pallas::Point);
 
 impl ValueCommitment {

--- a/taiga_halo2/src/value_commitment.rs
+++ b/taiga_halo2/src/value_commitment.rs
@@ -4,10 +4,12 @@ use halo2_proofs::arithmetic::CurveAffine;
 use pasta_curves::group::cofactor::CofactorCurveAffine;
 use pasta_curves::group::{Curve, Group, GroupEncoding};
 use pasta_curves::pallas;
+#[cfg(feature = "nif")]
 use rustler::NifTuple;
 use subtle::CtOption;
 
-#[derive(Copy, Clone, Debug, NifTuple)]
+#[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "nif", derive(NifTuple))]
 pub struct ValueCommitment(pallas::Point);
 
 impl ValueCommitment {


### PR DESCRIPTION
This Topic adds a serialization of many types found inside of Taiga to the BEAM (Erlang, Elixir).

We introduce a new dependnecy `rustler` but keep it hidden under a feature flag. This feature flag is off by default but can be turned on by building with `--features=nif`

Doing so allows any BEAM language to talk to the codebase


Each commit of this Topic has documentation, and it is best to review commit by commit, to see the commentary that goes with what changes.