### PR TITLE
Remove Merkle tree impl, add serialization for MerklePath, Node, Nullifier

### DIFF
--- a/taiga_halo2/Cargo.toml
+++ b/taiga_halo2/Cargo.toml
@@ -4,27 +4,27 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-rand = "0.8.4"
-lazy_static = "1"
-blake2b_simd = "1"
+rand = "0.8"
+lazy_static = "1.4"
+blake2b_simd = "1.0"
 pasta_curves = "0.5.1"
 ff = "0.13"
 group = "0.13"
-halo2_gadgets = {version = "0.3", features = ["test-dependencies"]}
-halo2_proofs = {version="0.3", features = ["dev-graph"]}
-bitvec = "1"
+halo2_gadgets = { version = "0.3", features = ["test-dependencies"] }
+halo2_proofs = { version = "0.3", features = ["dev-graph"] }
+bitvec = "1.0"
 subtle = { version = "2.3", default-features = false }
 dyn-clone = "1.0"
 reddsa = "0.5"
 vamp-ir = { git = "https://github.com/anoma/vamp-ir.git", rev = "6d401f8a479951727586ef0c44c42edab3139090"}
 bincode = "2.0.0-rc.3"
-borsh = {version = "0.10.3", features = ["const-generics"]}
-byteorder = "1"
-num-bigint = "0.4.3"
+borsh = { version = "0.10", features = ["const-generics"] }
+byteorder = "1.4"
+num-bigint = "0.4"
 
 [dev-dependencies]
-criterion = "0.5.1"
-proptest = "1.0.0"
+criterion = "0.5"
+proptest = "1.2"
 
 [[bench]]
 name = "action_proof"

--- a/taiga_halo2/src/action.rs
+++ b/taiga_halo2/src/action.rs
@@ -122,7 +122,7 @@ impl ActionInfo {
 
         let cm_x = self.output_note.commitment().get_x();
         let anchor = {
-            let cm_node = Node::new(self.input_note.commitment().get_x());
+            let cm_node = Node::from_note(&self.input_note);
             self.input_merkle_path.root(cm_node).inner()
         };
 

--- a/taiga_halo2/src/circuit/merkle_circuit.rs
+++ b/taiga_halo2/src/circuit/merkle_circuit.rs
@@ -1,4 +1,5 @@
 use crate::circuit::gadgets::poseidon_hash::poseidon_hash_gadget;
+use crate::constant::TAIGA_COMMITMENT_TREE_DEPTH;
 use crate::merkle_tree::{is_left, LR};
 use halo2_gadgets::{
     poseidon::Pow5Config as PoseidonConfig,
@@ -108,7 +109,7 @@ pub fn merkle_poseidon_gadget(
 #[test]
 fn test_halo2_merkle_circuit() {
     use crate::circuit::gadgets::assign_free_advice;
-    use crate::merkle_tree::{tests::random_merkle_path, MerklePath, Node};
+    use crate::merkle_tree::{MerklePath, Node};
     use halo2_gadgets::poseidon::{primitives as poseidon, Pow5Chip as PoseidonChip};
     use halo2_proofs::{
         arithmetic::Field,
@@ -204,7 +205,7 @@ fn test_halo2_merkle_circuit() {
     let mut rng = OsRng;
 
     let leaf = pallas::Base::random(rng);
-    let merkle_path = random_merkle_path(&mut rng);
+    let merkle_path = MerklePath::random(&mut rng, TAIGA_COMMITMENT_TREE_DEPTH);
 
     let circuit = MyCircuit { leaf, merkle_path };
 

--- a/taiga_halo2/src/circuit/merkle_circuit.rs
+++ b/taiga_halo2/src/circuit/merkle_circuit.rs
@@ -1,5 +1,4 @@
 use crate::circuit::gadgets::poseidon_hash::poseidon_hash_gadget;
-use crate::constant::TAIGA_COMMITMENT_TREE_DEPTH;
 use crate::merkle_tree::{is_left, LR};
 use halo2_gadgets::{
     poseidon::Pow5Config as PoseidonConfig,
@@ -109,6 +108,7 @@ pub fn merkle_poseidon_gadget(
 #[test]
 fn test_halo2_merkle_circuit() {
     use crate::circuit::gadgets::assign_free_advice;
+    use crate::constant::TAIGA_COMMITMENT_TREE_DEPTH;
     use crate::merkle_tree::{MerklePath, Node};
     use halo2_gadgets::poseidon::{primitives as poseidon, Pow5Chip as PoseidonChip};
     use halo2_proofs::{

--- a/taiga_halo2/src/merkle_tree.rs
+++ b/taiga_halo2/src/merkle_tree.rs
@@ -47,45 +47,6 @@ impl Distribution<LR> for Standard {
     }
 }
 
-#[derive(Clone, BorshSerialize, BorshDeserialize)]
-pub struct MerkleTreeLeaves {
-    leaves: Vec<Node>,
-}
-
-impl MerkleTreeLeaves {
-    pub fn new(values: Vec<pallas::Base>) -> Self {
-        let nodes_vec = values.iter().map(|x| Node::new(*x)).collect::<Vec<_>>();
-        Self { leaves: nodes_vec }
-    }
-
-    pub fn root(&mut self) -> Node {
-        // the list of leaves is extended with copies of elements so that its length is a power of 2.
-        let list = &mut self.leaves;
-        let n = list.len();
-        let m = n.next_power_of_two();
-        let mut ext = list.clone();
-        ext.truncate(m - n);
-        list.extend(ext);
-
-        let mut len = list.len();
-        while len > 1 {
-            for i in 0..len / 2 {
-                list[i] = Node::combine(&list[2 * i], &list[2 * i + 1]);
-            }
-            len /= 2;
-        }
-        list[0]
-    }
-
-    pub fn insert(&mut self, value: pallas::Base) -> Self {
-        let leaves = &mut self.leaves;
-        leaves.push(Node::new(value));
-        Self {
-            leaves: leaves.to_vec(),
-        }
-    }
-}
-
 /// A path from a position in a particular commitment tree to the root of that tree.
 /// In Orchard merkle tree, they are using MerkleCRH(layer, left, right), where MerkleCRH is a sinsemilla. We are using poseidon_hash(left, right).
 #[derive(Clone, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
@@ -101,42 +62,6 @@ impl MerklePath {
     }
     /// Constructs a Merkle path directly from a path.
     pub fn from_path(merkle_path: Vec<(Node, LR)>) -> Self {
-        MerklePath { merkle_path }
-    }
-
-    pub fn find_sibling(leaf_hashes: &[Node], position: usize) -> (usize, Node) {
-        let pos = if position % 2 == 0 {
-            position + 1
-        } else {
-            position - 1
-        };
-        (pos, leaf_hashes[pos])
-    }
-
-    fn build_merkle_path_inner(
-        leaf_hashes: Vec<Node>,
-        position: usize,
-        path: &mut Vec<(Node, LR)>,
-    ) {
-        let mut new_leaves = vec![];
-        if leaf_hashes.len() > 1 {
-            let (sibling_pos, sibling) = Self::find_sibling(&leaf_hashes, position);
-            path.push((sibling, lr(sibling_pos)));
-
-            for pair in leaf_hashes.chunks(2) {
-                let hash_pair = Node::combine(&pair[0], &pair[1]);
-
-                new_leaves.push(hash_pair);
-            }
-
-            Self::build_merkle_path_inner(new_leaves, position / 2, path);
-        }
-    }
-
-    pub fn build_merkle_path(leaf_hashes: &[Node], position: usize) -> Self {
-        let mut merkle_path = vec![];
-        let completed_leaf_hashes = add_remaining_addresses(leaf_hashes);
-        Self::build_merkle_path_inner(completed_leaf_hashes, position, &mut merkle_path);
         MerklePath { merkle_path }
     }
 
@@ -161,15 +86,13 @@ impl MerklePath {
     }
 }
 
-fn add_remaining_addresses(addresses: &[Node]) -> Vec<Node> {
-    let number_of_elems = addresses.len();
-    let next_power_of_two = number_of_elems.next_power_of_two();
-    let remaining = next_power_of_two - number_of_elems;
-    let slice = &addresses[..remaining];
-    let mut added = slice.to_vec();
-    let mut new_addresses = addresses.to_owned();
-    new_addresses.append(&mut added);
-    new_addresses
+impl Default for MerklePath {
+    fn default() -> MerklePath {
+        let merkle_path = (0..TAIGA_COMMITMENT_TREE_DEPTH)
+            .map(|_| (Node::new(pallas::Base::one()), L))
+            .collect();
+        Self::from_path(merkle_path)
+    }
 }
 
 /// A node within the Sapling commitment tree.
@@ -209,60 +132,5 @@ impl BorshDeserialize for Node {
             std::io::Error::new(std::io::ErrorKind::InvalidData, "Node value not in field")
         })?;
         Ok(Self(value))
-    }
-}
-
-impl Default for MerklePath {
-    fn default() -> MerklePath {
-        let merkle_path = (0..TAIGA_COMMITMENT_TREE_DEPTH)
-            .map(|_| (Node::new(pallas::Base::one()), L))
-            .collect();
-        Self::from_path(merkle_path)
-    }
-}
-
-#[cfg(test)]
-pub mod tests {
-    use super::*;
-    use crate::constant::TAIGA_COMMITMENT_TREE_DEPTH;
-    use crate::merkle_tree::Node;
-    use halo2_gadgets::poseidon::primitives as poseidon;
-    use pasta_curves::Fp;
-
-    pub fn random_merkle_path<R: RngCore>(mut rng: R) -> MerklePath {
-        MerklePath::random(&mut rng, TAIGA_COMMITMENT_TREE_DEPTH)
-    }
-
-    #[test]
-    // Test a Merkle tree with 4 leaves
-    fn test_merkle_path_4() {
-        let mut rng = rand::thread_rng();
-
-        let hashes: Vec<Node> = (0..4)
-            .map(|_| {
-                let poseidon = poseidon::Hash::<
-                    _,
-                    poseidon::P128Pow5T3,
-                    poseidon::ConstantLength<4>,
-                    3,
-                    2,
-                >::init();
-                let inputs: Vec<Fp> = (0..4).map(|_| Fp::from(rng.gen::<u64>())).collect();
-                let f = poseidon.hash(inputs.try_into().expect("slice with incorrect length"));
-                Node::new(f)
-            })
-            .collect();
-
-        let position = 1;
-
-        let hash_2_3 = poseidon_hash(hashes[2].inner(), hashes[3].inner());
-
-        let merkle_path = &[(Node::new(hashes[0].inner()), L), (Node::new(hash_2_3), R)];
-
-        let merkle_path = MerklePath::from_path(merkle_path.to_vec());
-
-        let merkle_path_2: MerklePath = MerklePath::build_merkle_path(&hashes, position);
-
-        assert_eq!(merkle_path, merkle_path_2);
     }
 }

--- a/taiga_halo2/src/merkle_tree.rs
+++ b/taiga_halo2/src/merkle_tree.rs
@@ -1,7 +1,7 @@
 //! Implementation of a Merkle tree of commitments used to prove the existence of notes.
 //!
-use crate::constant::TAIGA_COMMITMENT_TREE_DEPTH;
 use crate::utils::poseidon_hash;
+use crate::{constant::TAIGA_COMMITMENT_TREE_DEPTH, note::Note};
 use borsh::{BorshDeserialize, BorshSerialize};
 use ff::PrimeField;
 use halo2_proofs::arithmetic::Field;
@@ -32,18 +32,13 @@ pub fn is_left(p: LR) -> bool {
     }
 }
 
-pub fn lr(i: usize) -> LR {
-    if i % 2 == 0 {
-        L
-    } else {
-        R
-    }
-}
-
 impl Distribution<LR> for Standard {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> LR {
-        let u: usize = rng.gen();
-        lr(u)
+        if rng.gen_bool(0.5) {
+            L
+        } else {
+            R
+        }
     }
 }
 
@@ -102,6 +97,10 @@ pub struct Node(pallas::Base);
 impl Node {
     pub fn new(v: pallas::Base) -> Self {
         Self(v)
+    }
+
+    pub fn from_note(n: &Note) -> Self {
+        Self(n.commitment().get_x())
     }
 
     pub fn rand(rng: &mut impl RngCore) -> Self {

--- a/taiga_halo2/src/note.rs
+++ b/taiga_halo2/src/note.rs
@@ -544,8 +544,8 @@ pub mod tests {
     use super::{InputNoteProvingInfo, Note, NoteType, OutputNoteProvingInfo, RandomSeed};
     use crate::{
         circuit::vp_examples::tests::random_trivial_vp_circuit,
-        merkle_tree::tests::random_merkle_path,
         nullifier::{tests::*, Nullifier, NullifierKeyContainer},
+        merkle_tree::MerklePath, constant::TAIGA_COMMITMENT_TREE_DEPTH,
     };
     use halo2_proofs::arithmetic::Field;
     use pasta_curves::pallas;
@@ -591,7 +591,7 @@ pub mod tests {
 
     pub fn random_input_proving_info<R: RngCore>(mut rng: R) -> InputNoteProvingInfo {
         let note = random_input_note(&mut rng);
-        let merkle_path = random_merkle_path(&mut rng);
+        let merkle_path = MerklePath::random(&mut rng, TAIGA_COMMITMENT_TREE_DEPTH);
         let app_vp_verifying_info = Box::new(random_trivial_vp_circuit(&mut rng));
         let app_vp_verifying_info_dynamic = vec![];
         InputNoteProvingInfo::new(

--- a/taiga_halo2/src/note.rs
+++ b/taiga_halo2/src/note.rs
@@ -544,8 +544,9 @@ pub mod tests {
     use super::{InputNoteProvingInfo, Note, NoteType, OutputNoteProvingInfo, RandomSeed};
     use crate::{
         circuit::vp_examples::tests::random_trivial_vp_circuit,
+        constant::TAIGA_COMMITMENT_TREE_DEPTH,
+        merkle_tree::MerklePath,
         nullifier::{tests::*, Nullifier, NullifierKeyContainer},
-        merkle_tree::MerklePath, constant::TAIGA_COMMITMENT_TREE_DEPTH,
     };
     use halo2_proofs::arithmetic::Field;
     use pasta_curves::pallas;

--- a/taiga_halo2/src/shielded_ptx.rs
+++ b/taiga_halo2/src/shielded_ptx.rs
@@ -330,11 +330,12 @@ pub mod testing {
     use crate::{
         circuit::vp_circuit::ValidityPredicateVerifyingInfo,
         circuit::vp_examples::TrivialValidityPredicateCircuit,
+        constant::TAIGA_COMMITMENT_TREE_DEPTH,
+        merkle_tree::MerklePath,
         note::{InputNoteProvingInfo, Note, OutputNoteProvingInfo, RandomSeed},
         nullifier::{Nullifier, NullifierKeyContainer},
         shielded_ptx::ShieldedPartialTransaction,
-        utils::poseidon_hash, merkle_tree::MerklePath,
-        constant::TAIGA_COMMITMENT_TREE_DEPTH,
+        utils::poseidon_hash,
     };
     use halo2_proofs::arithmetic::Field;
     use pasta_curves::pallas;

--- a/taiga_halo2/src/shielded_ptx.rs
+++ b/taiga_halo2/src/shielded_ptx.rs
@@ -330,11 +330,11 @@ pub mod testing {
     use crate::{
         circuit::vp_circuit::ValidityPredicateVerifyingInfo,
         circuit::vp_examples::TrivialValidityPredicateCircuit,
-        merkle_tree::tests::random_merkle_path,
         note::{InputNoteProvingInfo, Note, OutputNoteProvingInfo, RandomSeed},
         nullifier::{Nullifier, NullifierKeyContainer},
         shielded_ptx::ShieldedPartialTransaction,
-        utils::poseidon_hash,
+        utils::poseidon_hash, merkle_tree::MerklePath,
+        constant::TAIGA_COMMITMENT_TREE_DEPTH,
     };
     use halo2_proofs::arithmetic::Field;
     use pasta_curves::pallas;
@@ -435,7 +435,7 @@ pub mod testing {
         };
 
         // Generate note info
-        let merkle_path = random_merkle_path(&mut rng);
+        let merkle_path = MerklePath::random(&mut rng, TAIGA_COMMITMENT_TREE_DEPTH);
         // Create vp circuit and fill the note info
         let mut trivial_vp_circuit = TrivialValidityPredicateCircuit {
             owned_note_pub_id: input_note_1.get_nf().unwrap().inner(),


### PR DESCRIPTION
- Bring a bit more order to the dependencies versions
- Remove Merkle tree implementation from Taiga codebase
- Remove Merkle tree test, as there's no more code to test
- Add `from_note` constructor to the Merkle tree `Node`
- Add Borsh (de)serialization for `Node`, `MerklePath`, and `Nullifier`