### PR TITLE
Remove reddsa from being a patch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,3 @@ members = [
 halo2_gadgets = { git="https://github.com/heliaxdev/halo2", branch="taiga"}
 halo2_proofs = { git="https://github.com/heliaxdev/halo2", branch="taiga"}
 pasta_curves = { git="https://github.com/heliaxdev/pasta_curves", branch="taiga"}
-reddsa = { git = "https://github.com/heliaxdev/reddsa", branch="taiga"}

--- a/taiga_halo2/Cargo.toml
+++ b/taiga_halo2/Cargo.toml
@@ -15,7 +15,7 @@ halo2_proofs = {version="0.3", features = ["dev-graph"]}
 bitvec = "1"
 subtle = { version = "2.3", default-features = false }
 dyn-clone = "1.0"
-reddsa = "0.5"
+reddsa = {git = "https://github.com/heliaxdev/reddsa.git", branch = "taiga"}
 vamp-ir = { git = "https://github.com/anoma/vamp-ir.git", rev = "6d401f8a479951727586ef0c44c42edab3139090"}
 bincode = "2.0.0-rc.3"
 borsh = {version = "0.10.3", features = ["const-generics"]}


### PR DESCRIPTION
Patches change how inner packages compile, this makes it so that if anyone uses the project as a library they too have to include the dependency as a patch, since this dep can work as a dependnecy and not a patch, it is moved into a dep