### PR TITLE
Specify the the specific topic branch for patch.crates-io

### DIFF
--- a/taiga_halo2/Cargo.toml
+++ b/taiga_halo2/Cargo.toml
@@ -7,11 +7,11 @@ edition = "2021"
 rand = "0.8.4"
 lazy_static = "1"
 blake2b_simd = "1"
-pasta_curves = "0.5.1"
+pasta_curves = {git = "https://github.com/heliaxdev/pasta_curves", branch = "taiga"}
 ff = "0.13"
 group = "0.13"
-halo2_gadgets = {version = "0.3", features = ["test-dependencies"]}
-halo2_proofs = {version="0.3", features = ["dev-graph"]}
+halo2_gadgets = {git = "https://github.com/heliaxdev/halo2", branch = "taiga", features = ["test-dependencies"]}
+halo2_proofs = {git = "https://github.com/heliaxdev/halo2", branch = "taiga", features = ["dev-graph"]}
 bitvec = "1"
 subtle = { version = "2.3", default-features = false }
 dyn-clone = "1.0"


### PR DESCRIPTION
Previously the topics specified a version, however it would be more correct to specify the same version that is found in the patch.crates-io, instead of just having them implicitly being the same.

Ideally we can remove the patch.crates-io in time