### PR TITLE
fix anchor generation

### DIFF
--- a/taiga_halo2/benches/action_proof.rs
+++ b/taiga_halo2/benches/action_proof.rs
@@ -13,7 +13,7 @@ use taiga_halo2::{
         ACTION_CIRCUIT_PARAMS_SIZE, ACTION_PROVING_KEY, ACTION_VERIFYING_KEY, SETUP_PARAMS_MAP,
         TAIGA_COMMITMENT_TREE_DEPTH,
     },
-    merkle_tree::MerklePath,
+    merkle_tree::{Anchor, MerklePath},
     note::{Note, NoteType, RandomSeed},
     nullifier::{Nullifier, NullifierKeyContainer},
 };
@@ -66,8 +66,9 @@ fn bench_action_proof(name: &str, c: &mut Criterion) {
             }
         };
         let input_merkle_path = MerklePath::random(&mut rng, TAIGA_COMMITMENT_TREE_DEPTH);
+        let anchor = Anchor::from(pallas::Base::random(&mut rng));
         let rseed = RandomSeed::random(&mut rng);
-        ActionInfo::new(input_note, input_merkle_path, output_note, rseed)
+        ActionInfo::new(input_note, input_merkle_path, anchor, output_note, rseed)
     };
     let (action, action_circuit) = action_info.build();
     let params = SETUP_PARAMS_MAP.get(&ACTION_CIRCUIT_PARAMS_SIZE).unwrap();

--- a/taiga_halo2/examples/tx_examples/cascaded_partial_transactions.rs
+++ b/taiga_halo2/examples/tx_examples/cascaded_partial_transactions.rs
@@ -15,7 +15,7 @@ use taiga_halo2::{
         },
     },
     constant::TAIGA_COMMITMENT_TREE_DEPTH,
-    merkle_tree::MerklePath,
+    merkle_tree::{Anchor, MerklePath},
     note::{InputNoteProvingInfo, OutputNoteProvingInfo},
     nullifier::{Nullifier, NullifierKeyContainer},
     shielded_ptx::ShieldedPartialTransaction,
@@ -67,6 +67,9 @@ pub fn create_transaction<R: RngCore + CryptoRng>(mut rng: R) -> Transaction {
     );
 
     let merkle_path = MerklePath::random(&mut rng, TAIGA_COMMITMENT_TREE_DEPTH);
+
+    // Fetch a valid anchor for dummy notes
+    let anchor = Anchor::from(pallas::Base::random(&mut rng));
 
     // The first partial transaction:
     // Alice consumes 1 "BTC" and 2 "ETH".
@@ -143,6 +146,7 @@ pub fn create_transaction<R: RngCore + CryptoRng>(mut rng: R) -> Transaction {
             InputNoteProvingInfo::new(
                 cascade_intent_note,
                 merkle_path.clone(),
+                Some(anchor),
                 Box::new(intent_vp),
                 vec![],
             )

--- a/taiga_halo2/examples/tx_examples/partial_fulfillment_token_swap.rs
+++ b/taiga_halo2/examples/tx_examples/partial_fulfillment_token_swap.rs
@@ -20,7 +20,7 @@ use taiga_halo2::{
         },
     },
     constant::TAIGA_COMMITMENT_TREE_DEPTH,
-    merkle_tree::MerklePath,
+    merkle_tree::{Anchor, MerklePath},
     note::{InputNoteProvingInfo, Note, OutputNoteProvingInfo},
     nullifier::{Nullifier, NullifierKeyContainer},
     shielded_ptx::ShieldedPartialTransaction,
@@ -70,6 +70,9 @@ pub fn create_token_intent_ptx<R: RngCore>(
 
     let merkle_path = MerklePath::random(&mut rng, TAIGA_COMMITMENT_TREE_DEPTH);
 
+    // Fetch a valid anchor for dummy notes
+    let anchor = Anchor::from(pallas::Base::random(&mut rng));
+
     // Create the input note proving info
     let input_note_proving_info = generate_input_token_note_proving_info(
         &mut rng,
@@ -101,6 +104,7 @@ pub fn create_token_intent_ptx<R: RngCore>(
     let padding_input_note_proving_info = InputNoteProvingInfo::create_padding_note_proving_info(
         padding_input_note,
         merkle_path,
+        anchor,
         input_notes,
         output_notes,
     );
@@ -182,6 +186,9 @@ pub fn consume_token_intent_ptx<R: RngCore>(
 
     let merkle_path = MerklePath::random(&mut rng, TAIGA_COMMITMENT_TREE_DEPTH);
 
+    // Fetch a valid anchor for dummy notes
+    let anchor = Anchor::from(pallas::Base::random(&mut rng));
+
     // Create the intent note proving info
     let intent_note_proving_info = {
         let intent_vp = PartialFulfillmentIntentValidityPredicateCircuit {
@@ -197,6 +204,7 @@ pub fn consume_token_intent_ptx<R: RngCore>(
         InputNoteProvingInfo::new(
             intent_note,
             merkle_path.clone(),
+            Some(anchor),
             Box::new(intent_vp),
             vec![],
         )
@@ -216,6 +224,7 @@ pub fn consume_token_intent_ptx<R: RngCore>(
     let padding_input_note_proving_info = InputNoteProvingInfo::create_padding_note_proving_info(
         padding_input_note,
         merkle_path,
+        anchor,
         input_notes,
         output_notes,
     );

--- a/taiga_halo2/examples/tx_examples/token.rs
+++ b/taiga_halo2/examples/tx_examples/token.rs
@@ -12,7 +12,7 @@ use taiga_halo2::{
         },
     },
     constant::TAIGA_COMMITMENT_TREE_DEPTH,
-    merkle_tree::MerklePath,
+    merkle_tree::{Anchor, MerklePath},
     note::{InputNoteProvingInfo, Note, OutputNoteProvingInfo, RandomSeed},
     nullifier::{Nullifier, NullifierKeyContainer},
     shielded_ptx::ShieldedPartialTransaction,
@@ -89,6 +89,9 @@ pub fn create_token_swap_ptx<R: RngCore>(
     // Generate proving info
     let merkle_path = MerklePath::random(&mut rng, TAIGA_COMMITMENT_TREE_DEPTH);
 
+    // Fetch a valid anchor for padding input notes
+    let anchor = Anchor::from(pallas::Base::random(&mut rng));
+
     // Create the input note proving info
     let input_note_proving_info = generate_input_token_note_proving_info(
         &mut rng,
@@ -115,6 +118,7 @@ pub fn create_token_swap_ptx<R: RngCore>(
     let padding_input_note_proving_info = InputNoteProvingInfo::create_padding_note_proving_info(
         padding_input_note,
         merkle_path,
+        anchor,
         input_notes,
         output_notes,
     );

--- a/taiga_halo2/src/circuit/vp_examples/token.rs
+++ b/taiga_halo2/src/circuit/vp_examples/token.rs
@@ -381,6 +381,7 @@ pub fn generate_input_token_note_proving_info<R: RngCore>(
     InputNoteProvingInfo::new(
         input_note,
         merkle_path,
+        None,
         Box::new(token_vp),
         vec![Box::new(token_auth_vp)],
     )

--- a/taiga_halo2/src/note.rs
+++ b/taiga_halo2/src/note.rs
@@ -489,11 +489,12 @@ impl InputNoteProvingInfo {
     pub fn new(
         note: Note,
         merkle_path: MerklePath,
-        anchor: Option<Anchor>,
+        // If no custom anchor is provided then the standard one is calculated from the note and path.
+        custom_anchor: Option<Anchor>,
         application_vp: Box<ValidityPredicate>,
         dynamic_vps: Vec<Box<ValidityPredicate>>,
     ) -> Self {
-        let anchor = match anchor {
+        let anchor = match custom_anchor {
             Some(anchor) => anchor,
             None => {
                 let cm_note = Node::from(&note);

--- a/taiga_halo2/src/note.rs
+++ b/taiga_halo2/src/note.rs
@@ -7,7 +7,7 @@ use crate::{
         NUM_NOTE, POSEIDON_TO_CURVE_INPUT_LEN, PRF_EXPAND_PERSONALIZATION, PRF_EXPAND_PSI,
         PRF_EXPAND_PUBLIC_INPUT_PADDING, PRF_EXPAND_RCM, PRF_EXPAND_VCM_R,
     },
-    merkle_tree::MerklePath,
+    merkle_tree::{Anchor, MerklePath, Node},
     nullifier::{Nullifier, NullifierKeyContainer},
     utils::{poseidon_hash_n, poseidon_to_curve},
 };
@@ -126,6 +126,7 @@ pub struct RandomSeed([u8; 32]);
 pub struct InputNoteProvingInfo {
     pub note: Note,
     pub merkle_path: MerklePath,
+    pub anchor: Anchor,
     application_vp: Box<ValidityPredicate>,
     dynamic_vps: Vec<Box<ValidityPredicate>>,
 }
@@ -488,12 +489,21 @@ impl InputNoteProvingInfo {
     pub fn new(
         note: Note,
         merkle_path: MerklePath,
+        anchor: Option<Anchor>,
         application_vp: Box<ValidityPredicate>,
         dynamic_vps: Vec<Box<ValidityPredicate>>,
     ) -> Self {
+        let anchor = match anchor {
+            Some(anchor) => anchor,
+            None => {
+                let cm_note = Node::from(&note);
+                merkle_path.root(cm_note)
+            }
+        };
         Self {
             note,
             merkle_path,
+            anchor,
             application_vp,
             dynamic_vps,
         }
@@ -510,6 +520,7 @@ impl InputNoteProvingInfo {
     pub fn create_padding_note_proving_info(
         padding_note: Note,
         merkle_path: MerklePath,
+        anchor: Anchor,
         input_notes: [Note; NUM_NOTE],
         output_notes: [Note; NUM_NOTE],
     ) -> Self {
@@ -518,7 +529,7 @@ impl InputNoteProvingInfo {
             input_notes,
             output_notes,
         });
-        InputNoteProvingInfo::new(padding_note, merkle_path, trivail_vp, vec![])
+        InputNoteProvingInfo::new(padding_note, merkle_path, Some(anchor), trivail_vp, vec![])
     }
 }
 
@@ -613,7 +624,7 @@ pub mod tests {
         let merkle_path = MerklePath::random(&mut rng, TAIGA_COMMITMENT_TREE_DEPTH);
         let application_vp = Box::new(random_trivial_vp_circuit(&mut rng));
         let dynamic_vps = vec![];
-        InputNoteProvingInfo::new(note, merkle_path, application_vp, dynamic_vps)
+        InputNoteProvingInfo::new(note, merkle_path, None, application_vp, dynamic_vps)
     }
 
     pub fn random_output_proving_info<R: RngCore>(

--- a/taiga_halo2/src/shielded_ptx.rs
+++ b/taiga_halo2/src/shielded_ptx.rs
@@ -542,6 +542,7 @@ pub mod testing {
         let input_note_proving_info_1 = InputNoteProvingInfo::new(
             input_note_1,
             merkle_path.clone(),
+            None,
             input_application_vp_1,
             trivial_dynamic_vps.clone(),
         );
@@ -552,6 +553,7 @@ pub mod testing {
         let input_note_proving_info_2 = InputNoteProvingInfo::new(
             input_note_2,
             merkle_path,
+            None,
             input_application_vp_2,
             dynamic_vps.clone(),
         );


### PR DESCRIPTION
The normal note anchor is generated from the path and note leaf, while the dummy(padding or intent) note anchor is from an existing valid root.