### PR TITLE
transparent ptx

### DIFF
--- a/taiga_halo2/src/error.rs
+++ b/taiga_halo2/src/error.rs
@@ -18,6 +18,10 @@ pub enum TransactionError {
     InconsistentOwnedNotePubID,
     /// IO error
     IoError(std::io::Error),
+    /// Transparent resource nullifier key is missing
+    MissingTransparentResourceNullifierKey,
+    /// Transparent resource merkle path is missing
+    MissingTransparentResourceMerklePath,
 }
 
 impl Display for TransactionError {
@@ -37,6 +41,12 @@ impl Display for TransactionError {
                 f.write_str("Owned note public id is not consistent between the action and the vp")
             }
             IoError(e) => f.write_str(&format!("IoError error: {e}")),
+            MissingTransparentResourceNullifierKey => {
+                f.write_str("Transparent resource nullifier key is missing")
+            }
+            MissingTransparentResourceMerklePath => {
+                f.write_str("Transparent resource merkle path is missing")
+            }
         }
     }
 }

--- a/taiga_halo2/src/taiga_api.rs
+++ b/taiga_halo2/src/taiga_api.rs
@@ -1,9 +1,7 @@
 #[cfg(feature = "borsh")]
 use crate::{
-    action::ActionInfo,
-    circuit::vp_bytecode::ApplicationByteCode,
-    error::TransactionError,
-    transaction::{ShieldedResult, TransparentResult},
+    action::ActionInfo, circuit::vp_bytecode::ApplicationByteCode, error::TransactionError,
+    transaction::TransactionResult,
 };
 use crate::{
     note::{Note, RandomSeed},
@@ -203,7 +201,7 @@ pub fn create_transaction(
 
 /// Verify a transaction and return the results
 ///
-/// ShieldedResult layout:
+/// TransactionResult layout:
 /// | Parameters     | type         | size(bytes)|
 /// |       -        |    -         |   -        |
 /// | anchor num     | u32          | 4          |
@@ -213,12 +211,8 @@ pub fn create_transaction(
 /// | output cm num  | u32          | 4          |
 /// | output cms     | pallas::Base | 32 * num   |
 ///
-/// Note: TransparentResult is empty
-///
 #[cfg(feature = "borsh")]
-pub fn verify_transaction(
-    tx_bytes: Vec<u8>,
-) -> Result<(ShieldedResult, TransparentResult), TransactionError> {
+pub fn verify_transaction(tx_bytes: Vec<u8>) -> Result<TransactionResult, TransactionError> {
     // Decode the tx
     let tx = transaction_deserialize(tx_bytes)?;
 

--- a/taiga_halo2/src/transparent_ptx.rs
+++ b/taiga_halo2/src/transparent_ptx.rs
@@ -1,6 +1,10 @@
 use crate::{
-    error::TransactionError, executable::Executable, merkle_tree::Anchor, note::NoteCommitment,
-    nullifier::Nullifier, value_commitment::ValueCommitment,
+    error::TransactionError,
+    executable::Executable,
+    merkle_tree::{Anchor, MerklePath},
+    note::{Note, NoteCommitment},
+    nullifier::{Nullifier, NullifierKeyContainer},
+    value_commitment::ValueCommitment,
 };
 
 #[cfg(feature = "serde")]
@@ -15,28 +19,61 @@ use borsh::{BorshDeserialize, BorshSerialize};
 pub struct TransparentPartialTransaction {
     pub inputs: Vec<InputResource>,
     pub outputs: Vec<OutputResource>,
+    pub hints: Vec<u8>,
 }
 
 impl Executable for TransparentPartialTransaction {
     fn execute(&self) -> Result<(), TransactionError> {
+        assert_eq!(self.inputs.len(), self.outputs.len());
+        for input in self.inputs.iter() {
+            // check nullifer_key is provided
+            if let NullifierKeyContainer::Commitment(_) = input.note.nk_container {
+                return Err(TransactionError::MissingTransparentResourceNullifierKey);
+            }
+
+            // check merkle_path is provided
+            if input.merkle_path.is_none() && input.note.is_merkle_checked {
+                return Err(TransactionError::MissingTransparentResourceMerklePath);
+            }
+        }
+
         // TODO: figure out how transparent ptx executes
-        unimplemented!()
+        // VP should be checked here
+
+        Ok(())
     }
 
     fn get_nullifiers(&self) -> Vec<Nullifier> {
-        unimplemented!()
+        self.inputs
+            .iter()
+            .map(|resource| resource.note.get_nf().unwrap())
+            .collect()
     }
 
     fn get_output_cms(&self) -> Vec<NoteCommitment> {
-        unimplemented!()
+        self.outputs
+            .iter()
+            .map(|resource| resource.note.commitment())
+            .collect()
     }
 
     fn get_value_commitments(&self) -> Vec<ValueCommitment> {
-        unimplemented!()
+        vec![ValueCommitment::from_tranparent_resources(
+            &self.inputs,
+            &self.outputs,
+        )]
     }
 
     fn get_anchors(&self) -> Vec<Anchor> {
-        unimplemented!()
+        let mut anchors = Vec::new();
+        for input in self.inputs.iter() {
+            if input.note.is_merkle_checked {
+                if let Some(path) = &input.merkle_path {
+                    anchors.push(input.note.calculate_root(path));
+                }
+            }
+        }
+        anchors
     }
 }
 
@@ -44,38 +81,73 @@ impl Executable for TransparentPartialTransaction {
 #[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InputResource {
-    pub resource_logic: ResourceLogic,
-    pub prefix: ContentHash,
-    pub suffix: Vec<ContentHash>,
-    pub resource_data_static: ResourceDataStatic,
-    pub resource_data_dynamic: ResourceDataDynamic,
+    pub note: Note,
+    // Only normal notes need the path, while dummy(intent and padding) notes don't need the path to calculate the anchor.
+    pub merkle_path: Option<MerklePath>,
+    // TODO: figure out transparent vp reprentation and how to execute it.
+    //     pub static_vp:
+    //     pub dynamic_vps:
 }
 
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct OutputResource {
-    pub resource_logic: ResourceLogic,
-    pub resource_data_static: ResourceDataStatic,
-    pub resource_data_dynamic: ResourceDataDynamic,
+    pub note: Note,
+    // TODO: figure out transparent vp reprentation and how to execute it.
+    //     pub static_vp:
+    //     pub dynamic_vps:
 }
 
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct ResourceLogic {}
+#[cfg(test)]
+pub mod testing {
+    use crate::{
+        constant::TAIGA_COMMITMENT_TREE_DEPTH,
+        merkle_tree::MerklePath,
+        note::tests::{random_input_note, random_output_note},
+        transparent_ptx::*,
+    };
+    use rand::rngs::OsRng;
 
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct ContentHash {}
+    // No transparent vp included
+    pub fn create_transparent_ptx() -> TransparentPartialTransaction {
+        let mut rng = OsRng;
+        let input_resource_1 = {
+            let note = random_input_note(&mut rng);
+            let merkle_path = MerklePath::random(&mut rng, TAIGA_COMMITMENT_TREE_DEPTH);
+            InputResource {
+                note,
+                merkle_path: Some(merkle_path),
+            }
+        };
+        let output_resource_1 = {
+            let mut note = random_output_note(&mut rng, input_resource_1.note.rho);
+            // Adjust the random note to keep the balance
+            note.note_type = input_resource_1.note.note_type;
+            note.value = input_resource_1.note.value;
+            OutputResource { note }
+        };
 
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct ResourceDataStatic {}
+        let input_resource_2 = {
+            let mut note = random_input_note(&mut rng);
+            note.is_merkle_checked = false;
+            InputResource {
+                note,
+                merkle_path: None,
+            }
+        };
+        let output_resource_2 = {
+            let mut note = random_output_note(&mut rng, input_resource_2.note.rho);
+            // Adjust the random note to keep the balance
+            note.note_type = input_resource_2.note.note_type;
+            note.value = input_resource_2.note.value;
+            OutputResource { note }
+        };
 
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct ResourceDataDynamic {}
+        TransparentPartialTransaction {
+            inputs: vec![input_resource_1, input_resource_2],
+            outputs: vec![output_resource_1, output_resource_2],
+            hints: vec![],
+        }
+    }
+}


### PR DESCRIPTION
* Add trivial transparent partial transaction 
* unify `ShieldedResult` and `TransactionResult` to `TransactionResult`
* remove binding signature random from transparent ptx since all resources are open

Note: no transparent vp included in transparent ptx yet. Transparent ptx only checks/executes the cryptographic information(e.g., nullifier, note commitment, value commitment, and anchor) used in shielded ptx. 