### PR TITLE
improve note commitment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ Cargo.lock
 book/book
 
 .DS_Store
+
+settings.json

--- a/taiga_halo2/src/circuit/action_circuit.rs
+++ b/taiga_halo2/src/circuit/action_circuit.rs
@@ -150,6 +150,7 @@ impl Circuit<pallas::Base> for ActionCircuit {
             meta,
             advices[0..3].try_into().unwrap(),
             poseidon_config.clone(),
+            range_check,
         );
 
         Self::Config {

--- a/taiga_halo2/src/circuit/integrity.rs
+++ b/taiga_halo2/src/circuit/integrity.rs
@@ -1,6 +1,7 @@
 use crate::circuit::{
     gadgets::{assign_free_advice, assign_free_constant, poseidon_hash::poseidon_hash_gadget},
     hash_to_curve::{hash_to_curve_circuit, HashToCurveConfig},
+    note_commitment::{note_commit, NoteCommitChip},
     vp_circuit::{InputNoteVariables, NoteVariables, OutputNoteVariables},
 };
 use crate::constant::{TaigaFixedBases, TaigaFixedBasesFull, POSEIDON_TO_CURVE_INPUT_LEN};
@@ -17,39 +18,6 @@ use halo2_proofs::{
 use pasta_curves::group::Curve;
 use pasta_curves::pallas;
 use std::ops::Neg;
-
-#[allow(clippy::too_many_arguments)]
-pub fn note_commitment_circuit(
-    mut layouter: impl Layouter<pallas::Base>,
-    poseidon_config: PoseidonConfig<pallas::Base, 3, 2>,
-    app_vp: AssignedCell<pallas::Base, pallas::Base>,
-    app_data_static: AssignedCell<pallas::Base, pallas::Base>,
-    app_data_dynamic: AssignedCell<pallas::Base, pallas::Base>,
-    nk_com: AssignedCell<pallas::Base, pallas::Base>,
-    rho: AssignedCell<pallas::Base, pallas::Base>,
-    psi: AssignedCell<pallas::Base, pallas::Base>,
-    value: AssignedCell<pallas::Base, pallas::Base>,
-    is_merkle_checked: AssignedCell<pallas::Base, pallas::Base>,
-    rcm: AssignedCell<pallas::Base, pallas::Base>,
-) -> Result<AssignedCell<pallas::Base, pallas::Base>, Error> {
-    // TODO: compose the value and is_merkle_checked to one field in order to save one poseidon absorb
-    let poseidon_message = [
-        app_vp,
-        app_data_static,
-        app_data_dynamic,
-        nk_com,
-        rho,
-        psi,
-        is_merkle_checked,
-        value,
-        rcm,
-    ];
-    poseidon_hash_gadget(
-        poseidon_config,
-        layouter.namespace(|| "note commitment"),
-        poseidon_message,
-    )
-}
 
 // cm is a field element
 #[allow(clippy::too_many_arguments)]
@@ -75,8 +43,7 @@ pub fn check_input_note(
     mut layouter: impl Layouter<pallas::Base>,
     advices: [Column<Advice>; 10],
     instances: Column<Instance>,
-    // PoseidonChip can not be cloned, use PoseidonConfig temporarily
-    poseidon_config: PoseidonConfig<pallas::Base, 3, 2>,
+    note_commit_chip: NoteCommitChip,
     input_note: Note,
     nf_row_idx: usize,
 ) -> Result<InputNoteVariables, Error> {
@@ -96,7 +63,7 @@ pub fn check_input_note(
 
     // nk_com = Com_r(nk, zero)
     let nk_com = poseidon_hash_gadget(
-        poseidon_config.clone(),
+        note_commit_chip.get_poseidon_config(),
         layouter.namespace(|| "nk_com encoding"),
         [nk_var.clone(), zero_constant],
     )?;
@@ -151,6 +118,7 @@ pub fn check_input_note(
     )?;
 
     // Witness is_merkle_checked
+    // is_merkle_checked will be boolean-constrained in the note_commit.
     let is_merkle_checked = assign_free_advice(
         layouter.namespace(|| "witness is_merkle_checked"),
         advices[0],
@@ -158,9 +126,9 @@ pub fn check_input_note(
     )?;
 
     // Check note commitment
-    let cm = note_commitment_circuit(
+    let cm = note_commit(
         layouter.namespace(|| "note commitment"),
-        poseidon_config.clone(),
+        note_commit_chip.clone(),
         app_vk.clone(),
         app_data_static.clone(),
         app_data_dynamic.clone(),
@@ -175,7 +143,7 @@ pub fn check_input_note(
     // Generate nullifier
     let nf = nullifier_circuit(
         layouter.namespace(|| "Generate nullifier"),
-        poseidon_config,
+        note_commit_chip.get_poseidon_config(),
         nk_var,
         rho.clone(),
         psi.clone(),
@@ -209,9 +177,7 @@ pub fn check_output_note(
     mut layouter: impl Layouter<pallas::Base>,
     advices: [Column<Advice>; 10],
     instances: Column<Instance>,
-    // PoseidonChip can not be cloned, use PoseidonConfig temporarily
-    poseidon_config: PoseidonConfig<pallas::Base, 3, 2>,
-    // poseidon_chip: PoseidonChip<pallas::Base, 3, 2>,
+    note_commit_chip: NoteCommitChip,
     output_note: Note,
     old_nf: AssignedCell<pallas::Base, pallas::Base>,
     cm_row_idx: usize,
@@ -266,6 +232,7 @@ pub fn check_output_note(
     )?;
 
     // Witness is_merkle_checked
+    // is_merkle_checked will be boolean-constrained in the note_commit.
     let is_merkle_checked = assign_free_advice(
         layouter.namespace(|| "witness is_merkle_checked"),
         advices[0],
@@ -273,9 +240,9 @@ pub fn check_output_note(
     )?;
 
     // Check note commitment
-    let cm = note_commitment_circuit(
+    let cm = note_commit(
         layouter.namespace(|| "note commitment"),
-        poseidon_config.clone(),
+        note_commit_chip,
         app_vk.clone(),
         app_data_static.clone(),
         app_data_dynamic.clone(),

--- a/taiga_halo2/src/circuit/mod.rs
+++ b/taiga_halo2/src/circuit/mod.rs
@@ -8,6 +8,7 @@ pub mod vp_circuit;
 pub mod blake2s;
 pub mod curve;
 pub mod hash_to_curve;
+pub mod note_commitment;
 pub mod note_encryption_circuit;
 mod vamp_ir_utils;
 #[cfg(feature = "borsh")]

--- a/taiga_halo2/src/circuit/note_commitment.rs
+++ b/taiga_halo2/src/circuit/note_commitment.rs
@@ -1,0 +1,168 @@
+use crate::circuit::gadgets::poseidon_hash::poseidon_hash_gadget;
+use group::ff::PrimeField;
+use halo2_gadgets::{poseidon::Pow5Config as PoseidonConfig, utilities::bool_check};
+use halo2_proofs::{
+    circuit::{AssignedCell, Layouter},
+    plonk::{Advice, Column, ConstraintSystem, Constraints, Error, Selector},
+    poly::Rotation,
+};
+use pasta_curves::pallas;
+
+/// compose = is_merkle_checked(bool) * 2^128 + value(64 bits)
+#[derive(Clone, Debug)]
+struct ComposeMerkleCheckValue {
+    q_compose: Selector,
+    col_l: Column<Advice>,
+    col_m: Column<Advice>,
+    col_r: Column<Advice>,
+}
+
+impl ComposeMerkleCheckValue {
+    fn configure(
+        meta: &mut ConstraintSystem<pallas::Base>,
+        col_l: Column<Advice>,
+        col_m: Column<Advice>,
+        col_r: Column<Advice>,
+        two_pow_128: pallas::Base,
+    ) -> Self {
+        let q_compose = meta.selector();
+
+        meta.create_gate("Compose is_merkle_checked and value", |meta| {
+            let q_compose = meta.query_selector(q_compose);
+
+            let compose_is_merkle_checked_and_value = meta.query_advice(col_l, Rotation::cur());
+            let is_merkle_checked = meta.query_advice(col_m, Rotation::cur());
+            let value = meta.query_advice(col_r, Rotation::cur());
+
+            // e = value + (2^128) * is_merkle_checked
+            let composition_check = compose_is_merkle_checked_and_value
+                - (value + is_merkle_checked.clone() * two_pow_128);
+
+            Constraints::with_selector(
+                q_compose,
+                [
+                    (
+                        "bool_check is_merkle_checked",
+                        bool_check(is_merkle_checked),
+                    ),
+                    ("composition", composition_check),
+                ],
+            )
+        });
+
+        Self {
+            q_compose,
+            col_l,
+            col_m,
+            col_r,
+        }
+    }
+
+    fn assign(
+        &self,
+        layouter: &mut impl Layouter<pallas::Base>,
+        is_merkle_checked: &AssignedCell<pallas::Base, pallas::Base>,
+        value: &AssignedCell<pallas::Base, pallas::Base>,
+    ) -> Result<AssignedCell<pallas::Base, pallas::Base>, Error> {
+        layouter.assign_region(
+            || "NoteCommit MessagePiece e",
+            |mut region| {
+                self.q_compose.enable(&mut region, 0)?;
+
+                let compose = is_merkle_checked.value().zip(value.value()).map(
+                    |(is_merkle_checked, value)| {
+                        value + is_merkle_checked * pallas::Base::from_u128(1 << 64).square()
+                    },
+                );
+                is_merkle_checked.copy_advice(
+                    || "is_merkle_checked",
+                    &mut region,
+                    self.col_m,
+                    0,
+                )?;
+                value.copy_advice(|| "value", &mut region, self.col_r, 0)?;
+
+                region.assign_advice(|| "compose", self.col_l, 0, || compose)
+            },
+        )
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct NoteCommitConfig {
+    compose_config: ComposeMerkleCheckValue,
+    poseidon_config: PoseidonConfig<pallas::Base, 3, 2>,
+}
+
+#[derive(Clone, Debug)]
+pub struct NoteCommitChip {
+    config: NoteCommitConfig,
+}
+
+impl NoteCommitChip {
+    pub fn configure(
+        meta: &mut ConstraintSystem<pallas::Base>,
+        advices: [Column<Advice>; 3],
+        poseidon_config: PoseidonConfig<pallas::Base, 3, 2>,
+    ) -> NoteCommitConfig {
+        let two_pow_128 = pallas::Base::from_u128(1 << 64).square();
+        let compose_config = ComposeMerkleCheckValue::configure(
+            meta,
+            advices[0],
+            advices[1],
+            advices[2],
+            two_pow_128,
+        );
+
+        NoteCommitConfig {
+            compose_config,
+            poseidon_config,
+        }
+    }
+
+    pub fn construct(config: NoteCommitConfig) -> Self {
+        NoteCommitChip { config }
+    }
+
+    pub fn get_poseidon_config(&self) -> PoseidonConfig<pallas::Base, 3, 2> {
+        self.config.poseidon_config.clone()
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn note_commit(
+    mut layouter: impl Layouter<pallas::Base>,
+    chip: NoteCommitChip,
+    app_vp: AssignedCell<pallas::Base, pallas::Base>,
+    app_data_static: AssignedCell<pallas::Base, pallas::Base>,
+    app_data_dynamic: AssignedCell<pallas::Base, pallas::Base>,
+    nk_com: AssignedCell<pallas::Base, pallas::Base>,
+    rho: AssignedCell<pallas::Base, pallas::Base>,
+    psi: AssignedCell<pallas::Base, pallas::Base>,
+    value: AssignedCell<pallas::Base, pallas::Base>,
+    is_merkle_checked: AssignedCell<pallas::Base, pallas::Base>,
+    rcm: AssignedCell<pallas::Base, pallas::Base>,
+) -> Result<AssignedCell<pallas::Base, pallas::Base>, Error> {
+    // Compose the value and is_merkle_checked to one field in order to save one poseidon absorb
+    let compose_is_merkle_checked_and_value =
+        chip.config
+            .compose_config
+            .assign(&mut layouter, &is_merkle_checked, &value)?;
+
+    // note commitment
+    let poseidon_message = [
+        app_vp,
+        app_data_static,
+        app_data_dynamic,
+        nk_com,
+        rho,
+        psi,
+        compose_is_merkle_checked_and_value,
+        rcm,
+    ];
+    poseidon_hash_gadget(
+        chip.config.poseidon_config,
+        layouter.namespace(|| "note commitment"),
+        poseidon_message,
+    )
+}

--- a/taiga_halo2/src/circuit/note_commitment.rs
+++ b/taiga_halo2/src/circuit/note_commitment.rs
@@ -1,6 +1,9 @@
 use crate::circuit::gadgets::poseidon_hash::poseidon_hash_gadget;
 use group::ff::PrimeField;
-use halo2_gadgets::{poseidon::Pow5Config as PoseidonConfig, utilities::bool_check};
+use halo2_gadgets::{
+    poseidon::Pow5Config as PoseidonConfig,
+    utilities::{bool_check, lookup_range_check::LookupRangeCheckConfig},
+};
 use halo2_proofs::{
     circuit::{AssignedCell, Layouter},
     plonk::{Advice, Column, ConstraintSystem, Constraints, Error, Selector},
@@ -92,6 +95,7 @@ impl ComposeMerkleCheckValue {
 pub struct NoteCommitConfig {
     compose_config: ComposeMerkleCheckValue,
     poseidon_config: PoseidonConfig<pallas::Base, 3, 2>,
+    lookup_config: LookupRangeCheckConfig<pallas::Base, 10>,
 }
 
 #[derive(Clone, Debug)]
@@ -104,6 +108,7 @@ impl NoteCommitChip {
         meta: &mut ConstraintSystem<pallas::Base>,
         advices: [Column<Advice>; 3],
         poseidon_config: PoseidonConfig<pallas::Base, 3, 2>,
+        lookup_config: LookupRangeCheckConfig<pallas::Base, 10>,
     ) -> NoteCommitConfig {
         let two_pow_128 = pallas::Base::from_u128(1 << 64).square();
         let compose_config = ComposeMerkleCheckValue::configure(
@@ -117,6 +122,7 @@ impl NoteCommitChip {
         NoteCommitConfig {
             compose_config,
             poseidon_config,
+            lookup_config,
         }
     }
 
@@ -126,6 +132,10 @@ impl NoteCommitChip {
 
     pub fn get_poseidon_config(&self) -> PoseidonConfig<pallas::Base, 3, 2> {
         self.config.poseidon_config.clone()
+    }
+
+    pub fn get_lookup_config(&self) -> &LookupRangeCheckConfig<pallas::Base, 10> {
+        &self.config.lookup_config
     }
 }
 

--- a/taiga_halo2/src/circuit/vp_circuit.rs
+++ b/taiga_halo2/src/circuit/vp_circuit.rs
@@ -13,6 +13,7 @@ use crate::{
             target_note_variable::{GetIsInputNoteFlagConfig, GetOwnedNoteVariableConfig},
         },
         integrity::{check_input_note, check_output_note},
+        note_commitment::{NoteCommitChip, NoteCommitConfig},
         vamp_ir_utils::{get_circuit_assignments, parse, VariableAssignmentError},
     },
     constant::{
@@ -323,6 +324,7 @@ pub struct ValidityPredicateConfig {
     pub sub_config: SubConfig,
     pub mul_config: MulConfig,
     pub blake2s_config: Blake2sConfig<pallas::Base>,
+    pub note_commit_config: NoteCommitConfig,
 }
 
 impl ValidityPredicateConfig {
@@ -395,6 +397,11 @@ impl ValidityPredicateConfig {
         let extended_or_relation_config =
             ExtendedOrRelationConfig::configure(meta, [advices[0], advices[1], advices[2]]);
         let blake2s_config = Blake2sConfig::configure(meta, advices);
+        let note_commit_config = NoteCommitChip::configure(
+            meta,
+            advices[0..3].try_into().unwrap(),
+            poseidon_config.clone(),
+        );
         Self {
             advices,
             instances,
@@ -410,6 +417,7 @@ impl ValidityPredicateConfig {
             sub_config,
             mul_config,
             blake2s_config,
+            note_commit_config,
         }
     }
 }
@@ -444,6 +452,9 @@ pub trait ValidityPredicateCircuit: Circuit<pallas::Base> + ValidityPredicateVer
             },
         )?;
 
+        // Construct a note_commit chip
+        let note_commit_chip = NoteCommitChip::construct(config.note_commit_config.clone());
+
         let input_notes = self.get_input_notes();
         let output_notes = self.get_output_notes();
         let mut input_note_variables = vec![];
@@ -453,7 +464,7 @@ pub trait ValidityPredicateCircuit: Circuit<pallas::Base> + ValidityPredicateVer
                 layouter.namespace(|| "check input note"),
                 config.advices,
                 config.instances,
-                config.poseidon_config.clone(),
+                note_commit_chip.clone(),
                 input_notes[i],
                 i * 2,
             )?);
@@ -468,7 +479,7 @@ pub trait ValidityPredicateCircuit: Circuit<pallas::Base> + ValidityPredicateVer
                 layouter.namespace(|| "check output note"),
                 config.advices,
                 config.instances,
-                config.poseidon_config.clone(),
+                note_commit_chip.clone(),
                 output_notes[i],
                 old_nf,
                 i * 2 + 1,

--- a/taiga_halo2/src/circuit/vp_circuit.rs
+++ b/taiga_halo2/src/circuit/vp_circuit.rs
@@ -401,6 +401,7 @@ impl ValidityPredicateConfig {
             meta,
             advices[0..3].try_into().unwrap(),
             poseidon_config.clone(),
+            range_check,
         );
         Self {
             advices,

--- a/taiga_halo2/src/note.rs
+++ b/taiga_halo2/src/note.rs
@@ -229,6 +229,11 @@ impl Note {
 
     // note_commitment = poseidon_hash(app_vk || app_data_static || app_data_dynamic || nk_commitment || rho || psi || is_merkle_checked || value || rcm)
     pub fn commitment(&self) -> NoteCommitment {
+        let compose_is_merkle_checked_value = if self.is_merkle_checked {
+            pallas::Base::from_u128(1 << 64).square() + pallas::Base::from(self.value)
+        } else {
+            pallas::Base::from(self.value)
+        };
         let ret = poseidon_hash_n([
             self.get_app_vk(),
             self.get_app_data_static(),
@@ -236,8 +241,7 @@ impl Note {
             self.get_nk_commitment(),
             self.rho.inner(),
             self.psi,
-            pallas::Base::from(self.is_merkle_checked as u64),
-            pallas::Base::from(self.value),
+            compose_is_merkle_checked_value,
             self.rcm,
         ]);
         NoteCommitment(ret)


### PR DESCRIPTION
* compose `is_merkle_checked` and `value` to save one Poseidon absorb in note commitment(composition = value + (2^128) * is_merkle_checked)
* add boolean constraints on `is_merkle_checked`
* add value(quantity) range check(64bits) by lookup table