### PR TITLE
conceal binding_sig_r and hints of shielded ptx when tx is balanced

### DIFF
--- a/taiga_halo2/examples/tx_examples/cascaded_partial_transactions.rs
+++ b/taiga_halo2/examples/tx_examples/cascaded_partial_transactions.rs
@@ -176,7 +176,7 @@ pub fn create_transaction<R: RngCore + CryptoRng>(mut rng: R) -> Transaction {
     // Create the final transaction
     let shielded_tx_bundle = ShieldedPartialTxBundle::new(vec![ptx_1, ptx_2]);
     let transparent_ptx_bundle = TransparentPartialTxBundle::default();
-    Transaction::build(&mut rng, shielded_tx_bundle, transparent_ptx_bundle)
+    Transaction::build(&mut rng, shielded_tx_bundle, transparent_ptx_bundle).unwrap()
 }
 
 #[test]

--- a/taiga_halo2/examples/tx_examples/partial_fulfillment_token_swap.rs
+++ b/taiga_halo2/examples/tx_examples/partial_fulfillment_token_swap.rs
@@ -200,7 +200,7 @@ pub fn create_token_swap_transaction<R: RngCore + CryptoRng>(mut rng: R) -> Tran
     // Solver creates the final transaction
     let shielded_tx_bundle = ShieldedPartialTxBundle::new(vec![alice_ptx, bob_ptx, solver_ptx]);
     let transparent_ptx_bundle = TransparentPartialTxBundle::default();
-    Transaction::build(&mut rng, shielded_tx_bundle, transparent_ptx_bundle)
+    Transaction::build(&mut rng, shielded_tx_bundle, transparent_ptx_bundle).unwrap()
 }
 
 #[test]

--- a/taiga_halo2/examples/tx_examples/token_swap_with_intent.rs
+++ b/taiga_halo2/examples/tx_examples/token_swap_with_intent.rs
@@ -277,7 +277,7 @@ pub fn create_token_swap_intent_transaction<R: RngCore + CryptoRng>(mut rng: R) 
     // Solver creates the final transaction
     let shielded_tx_bundle = ShieldedPartialTxBundle::new(vec![alice_ptx, bob_ptx, solver_ptx]);
     let transparent_ptx_bundle = TransparentPartialTxBundle::default();
-    Transaction::build(&mut rng, shielded_tx_bundle, transparent_ptx_bundle)
+    Transaction::build(&mut rng, shielded_tx_bundle, transparent_ptx_bundle).unwrap()
 }
 
 #[test]

--- a/taiga_halo2/examples/tx_examples/token_swap_without_intent.rs
+++ b/taiga_halo2/examples/tx_examples/token_swap_without_intent.rs
@@ -69,7 +69,7 @@ pub fn create_token_swap_transaction<R: RngCore + CryptoRng>(mut rng: R) -> Tran
     // Solver creates the final transaction
     let shielded_tx_bundle = ShieldedPartialTxBundle::new(vec![alice_ptx, bob_ptx, carol_ptx]);
     let transparent_ptx_bundle = TransparentPartialTxBundle::default();
-    Transaction::build(&mut rng, shielded_tx_bundle, transparent_ptx_bundle)
+    Transaction::build(&mut rng, shielded_tx_bundle, transparent_ptx_bundle).unwrap()
 }
 
 #[test]

--- a/taiga_halo2/src/error.rs
+++ b/taiga_halo2/src/error.rs
@@ -22,6 +22,8 @@ pub enum TransactionError {
     MissingTransparentResourceNullifierKey,
     /// Transparent resource merkle path is missing
     MissingTransparentResourceMerklePath,
+    /// Shielded partial Tx binding signature r is missing
+    MissingPartialTxBindingSignatureR,
 }
 
 impl Display for TransactionError {
@@ -46,6 +48,9 @@ impl Display for TransactionError {
             }
             MissingTransparentResourceMerklePath => {
                 f.write_str("Transparent resource merkle path is missing")
+            }
+            MissingPartialTxBindingSignatureR => {
+                f.write_str("Shielded partial Tx binding signature r is missing")
             }
         }
     }

--- a/taiga_halo2/src/taiga_api.rs
+++ b/taiga_halo2/src/taiga_api.rs
@@ -1,9 +1,9 @@
 #[cfg(feature = "borsh")]
 use crate::{
-    action::ActionInfo, circuit::vp_bytecode::ApplicationByteCode, error::TransactionError,
-    transaction::TransactionResult,
+    action::ActionInfo, circuit::vp_bytecode::ApplicationByteCode, transaction::TransactionResult,
 };
 use crate::{
+    error::TransactionError,
     note::{Note, RandomSeed},
     nullifier::{Nullifier, NullifierKeyContainer},
     shielded_ptx::ShieldedPartialTransaction,
@@ -133,7 +133,7 @@ pub fn note_deserialize(bytes: Vec<u8>) -> std::io::Result<Note> {
 /// | output2 static vp proof           | VPVerifyingInfo       | 158216        |
 /// | output2 dynamic vp num(by borsh)  | u32                   | 4             |
 /// | output2 dynamic vp proofs         | VPVerifyingInfo       | 158216 * num  |
-/// | binding_sig_r                     | pallas::Scalar        | 32            |
+/// | binding_sig_r                     | Option<pallas::Scalar>| 1 or (1 + 32) |
 /// | hints                             | Vec<u8>               | -             |
 ///
 /// Note: Ultimately, vp proofs won't go to the ptx. It's verifier proofs instead.
@@ -191,7 +191,7 @@ pub fn create_transaction(
     shielded_ptxs: Vec<ShieldedPartialTransaction>,
     // TODO: add transparent_ptxs
     // transparent_ptxs: Vec<TransparentPartialTransaction>,
-) -> Transaction {
+) -> Result<Transaction, TransactionError> {
     let rng = OsRng;
     let shielded_ptx_bundle = ShieldedPartialTxBundle::new(shielded_ptxs);
     // empty transparent_ptx_bundle


### PR DESCRIPTION
The `binding_sig_r` and `hints` of shielded ptx should not be exposed to the public when the ptx is added to the tx and the tx is balanced.