### PR TITLE
refactor shielded ptx building

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "rust-analyzer.showUnlinkedFileNotification": false
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "rust-analyzer.showUnlinkedFileNotification": false
-}

--- a/taiga_halo2/benches/action_proof.rs
+++ b/taiga_halo2/benches/action_proof.rs
@@ -67,8 +67,7 @@ fn bench_action_proof(name: &str, c: &mut Criterion) {
         };
         let input_merkle_path = MerklePath::random(&mut rng, TAIGA_COMMITMENT_TREE_DEPTH);
         let anchor = input_note.calculate_root(&input_merkle_path);
-        let rseed = RandomSeed::random(&mut rng);
-        ActionInfo::new(input_note, input_merkle_path, anchor, output_note, rseed)
+        ActionInfo::new(input_note, input_merkle_path, anchor, output_note, &mut rng)
     };
     let (action, action_circuit) = action_info.build();
     let params = SETUP_PARAMS_MAP.get(&ACTION_CIRCUIT_PARAMS_SIZE).unwrap();

--- a/taiga_halo2/benches/action_proof.rs
+++ b/taiga_halo2/benches/action_proof.rs
@@ -43,7 +43,7 @@ fn bench_action_proof(name: &str, c: &mut Criterion) {
                 rho,
             }
         };
-        let output_note = {
+        let mut output_note = {
             let rho = input_note.get_nf().unwrap();
             let nk_com = NullifierKeyContainer::from_commitment(pallas::Base::random(&mut rng));
             let note_type = {
@@ -66,8 +66,13 @@ fn bench_action_proof(name: &str, c: &mut Criterion) {
             }
         };
         let input_merkle_path = MerklePath::random(&mut rng, TAIGA_COMMITMENT_TREE_DEPTH);
-        let anchor = input_note.calculate_root(&input_merkle_path);
-        ActionInfo::new(input_note, input_merkle_path, anchor, output_note, &mut rng)
+        ActionInfo::new(
+            input_note,
+            input_merkle_path,
+            None,
+            &mut output_note,
+            &mut rng,
+        )
     };
     let (action, action_circuit) = action_info.build();
     let params = SETUP_PARAMS_MAP.get(&ACTION_CIRCUIT_PARAMS_SIZE).unwrap();

--- a/taiga_halo2/examples/tx_examples/cascaded_partial_transactions.rs
+++ b/taiga_halo2/examples/tx_examples/cascaded_partial_transactions.rs
@@ -5,6 +5,7 @@ use halo2_proofs::arithmetic::Field;
 use pasta_curves::pallas;
 use rand::{CryptoRng, RngCore};
 use taiga_halo2::{
+    action::ActionInfo,
     circuit::vp_examples::{
         cascade_intent::{create_intent_note, CascadeIntentValidityPredicateCircuit},
         signature_verification::COMPRESSED_TOKEN_AUTH_VK,
@@ -12,7 +13,7 @@ use taiga_halo2::{
     },
     constant::TAIGA_COMMITMENT_TREE_DEPTH,
     merkle_tree::{Anchor, MerklePath},
-    note::{InputNoteProvingInfo, OutputNoteProvingInfo},
+    note::{NoteValidityPredicates, RandomSeed},
     nullifier::{Nullifier, NullifierKeyContainer},
     shielded_ptx::ShieldedPartialTransaction,
     transaction::{ShieldedPartialTxBundle, Transaction, TransparentPartialTxBundle},
@@ -71,106 +72,160 @@ pub fn create_transaction<R: RngCore + CryptoRng>(mut rng: R) -> Transaction {
     // Alice consumes 1 "BTC" and 2 "ETH".
     // Alice creates a cascade intent note and 1 "BTC" to Bob.
     let ptx_1 = {
-        let input_notes = [*input_note_1.note(), *input_note_2.note()];
-        let output_notes = [*output_note_1.note(), cascade_intent_note];
-        // Create the input note proving info
-        let input_note_1_proving_info = input_note_1.generate_input_token_note_proving_info(
-            &mut rng,
-            alice_auth,
-            alice_auth_sk,
-            merkle_path.clone(),
-            input_notes,
-            output_notes,
-        );
-        let input_note_2_proving_info = input_note_2.generate_input_token_note_proving_info(
-            &mut rng,
-            alice_auth,
-            alice_auth_sk,
-            merkle_path.clone(),
-            input_notes,
-            output_notes,
-        );
+        // Create action pairs
+        let actions = {
+            let rseed_1 = RandomSeed::random(&mut rng);
+            let anchor_1 = input_note_1.calculate_root(&merkle_path);
+            let action_1 = ActionInfo::new(
+                *input_note_1.note(),
+                merkle_path.clone(),
+                anchor_1,
+                *output_note_1.note(),
+                rseed_1,
+            );
 
-        // Create the output note proving info
-        let output_note_1_proving_info = output_note_1.generate_output_token_note_proving_info(
-            &mut rng,
-            bob_auth,
-            input_notes,
-            output_notes,
-        );
+            let rseed_2 = RandomSeed::random(&mut rng);
+            let anchor_2 = input_note_2.calculate_root(&merkle_path);
+            let action_2 = ActionInfo::new(
+                *input_note_2.note(),
+                merkle_path.clone(),
+                anchor_2,
+                cascade_intent_note,
+                rseed_2,
+            );
+            vec![action_1, action_2]
+        };
 
-        let intent_note_proving_info = {
-            let intent_vp = CascadeIntentValidityPredicateCircuit {
-                owned_note_pub_id: cascade_intent_note.commitment().inner(),
+        // Create VPs
+        let (input_vps, output_vps) = {
+            let input_notes = [*input_note_1.note(), *input_note_2.note()];
+            let output_notes = [*output_note_1.note(), cascade_intent_note];
+
+            // Create the input note_1 vps
+            let input_note_1_vps = input_note_1.generate_input_token_vps(
+                &mut rng,
+                alice_auth,
+                alice_auth_sk,
                 input_notes,
                 output_notes,
-                cascade_note_cm: cascade_intent_note.get_app_data_static(),
+            );
+
+            // Create the input note_2 vps
+            let input_note_2_vps = input_note_2.generate_input_token_vps(
+                &mut rng,
+                alice_auth,
+                alice_auth_sk,
+                input_notes,
+                output_notes,
+            );
+
+            // Create the output note_1 vps
+            let output_note_1_vps = output_note_1.generate_output_token_vps(
+                &mut rng,
+                bob_auth,
+                input_notes,
+                output_notes,
+            );
+
+            // Create intent vps
+            let intent_vps = {
+                let intent_vp = CascadeIntentValidityPredicateCircuit {
+                    owned_note_pub_id: cascade_intent_note.commitment().inner(),
+                    input_notes,
+                    output_notes,
+                    cascade_note_cm: cascade_intent_note.get_app_data_static(),
+                };
+
+                NoteValidityPredicates::new(Box::new(intent_vp), vec![])
             };
 
-            OutputNoteProvingInfo::new(cascade_intent_note, Box::new(intent_vp), vec![])
+            (
+                vec![input_note_1_vps, input_note_2_vps],
+                vec![output_note_1_vps, intent_vps],
+            )
         };
 
         // Create shielded partial tx
-        ShieldedPartialTransaction::build(
-            [input_note_1_proving_info, input_note_2_proving_info],
-            [output_note_1_proving_info, intent_note_proving_info],
-            vec![],
-            &mut rng,
-        )
+        ShieldedPartialTransaction::build(actions, input_vps, output_vps, vec![], &mut rng).unwrap()
     };
 
     // The second partial transaction:
     // Alice consumes the intent note and 3 "XAN";
     // Alice creates 2 "ETH" and 3 "XAN" to Bob
     let ptx_2 = {
-        let input_notes = [cascade_intent_note, *input_note_3.note()];
-        let output_notes = [*output_note_2.note(), *output_note_3.note()];
-        // Create the input note proving info
-        let intent_note_proving_info = {
-            let intent_vp = CascadeIntentValidityPredicateCircuit {
-                owned_note_pub_id: cascade_intent_note.get_nf().unwrap().inner(),
-                input_notes,
-                output_notes,
-                cascade_note_cm: cascade_intent_note.get_app_data_static(),
-            };
-
-            InputNoteProvingInfo::new(
+        // Create action pairs
+        let actions = {
+            let rseed_1 = RandomSeed::random(&mut rng);
+            let action_1 = ActionInfo::new(
                 cascade_intent_note,
                 merkle_path.clone(),
-                Some(anchor),
-                Box::new(intent_vp),
-                vec![],
+                anchor,
+                *output_note_2.note(),
+                rseed_1,
+            );
+
+            let rseed_2 = RandomSeed::random(&mut rng);
+            let anchor_2 = input_note_3.calculate_root(&merkle_path);
+            let action_2 = ActionInfo::new(
+                *input_note_3.note(),
+                merkle_path,
+                anchor_2,
+                *output_note_3.note(),
+                rseed_2,
+            );
+            vec![action_1, action_2]
+        };
+
+        // Create VPs
+        let (input_vps, output_vps) = {
+            let input_notes = [cascade_intent_note, *input_note_3.note()];
+            let output_notes = [*output_note_2.note(), *output_note_3.note()];
+
+            // Create intent vps
+            let intent_vps = {
+                let intent_vp = CascadeIntentValidityPredicateCircuit {
+                    owned_note_pub_id: cascade_intent_note.get_nf().unwrap().inner(),
+                    input_notes,
+                    output_notes,
+                    cascade_note_cm: cascade_intent_note.get_app_data_static(),
+                };
+
+                NoteValidityPredicates::new(Box::new(intent_vp), vec![])
+            };
+
+            // Create input note_3 vps
+            let input_note_3_vps = input_note_3.generate_input_token_vps(
+                &mut rng,
+                alice_auth,
+                alice_auth_sk,
+                input_notes,
+                output_notes,
+            );
+
+            // Create output note_2 vps
+            let output_note_2_vps = output_note_2.generate_output_token_vps(
+                &mut rng,
+                bob_auth,
+                input_notes,
+                output_notes,
+            );
+
+            // Create output note_3 vps
+            let output_note_3_vps = output_note_3.generate_output_token_vps(
+                &mut rng,
+                bob_auth,
+                input_notes,
+                output_notes,
+            );
+
+            (
+                vec![intent_vps, input_note_3_vps],
+                vec![output_note_2_vps, output_note_3_vps],
             )
         };
-        let input_note_3_proving_info = input_note_3.generate_input_token_note_proving_info(
-            &mut rng,
-            alice_auth,
-            alice_auth_sk,
-            merkle_path,
-            input_notes,
-            output_notes,
-        );
-        // Create the output note proving info
-        let output_note_2_proving_info = output_note_2.generate_output_token_note_proving_info(
-            &mut rng,
-            bob_auth,
-            input_notes,
-            output_notes,
-        );
-        let output_note_3_proving_info = output_note_3.generate_output_token_note_proving_info(
-            &mut rng,
-            bob_auth,
-            input_notes,
-            output_notes,
-        );
 
         // Create shielded partial tx
-        ShieldedPartialTransaction::build(
-            [intent_note_proving_info, input_note_3_proving_info],
-            [output_note_2_proving_info, output_note_3_proving_info],
-            vec![],
-            &mut rng,
-        )
+        ShieldedPartialTransaction::build(actions, input_vps, output_vps, vec![], &mut rng).unwrap()
     };
 
     // Create the final transaction

--- a/taiga_halo2/examples/tx_examples/cascaded_partial_transactions.rs
+++ b/taiga_halo2/examples/tx_examples/cascaded_partial_transactions.rs
@@ -13,7 +13,7 @@ use taiga_halo2::{
     },
     constant::TAIGA_COMMITMENT_TREE_DEPTH,
     merkle_tree::{Anchor, MerklePath},
-    note::{NoteValidityPredicates, RandomSeed},
+    note::NoteValidityPredicates,
     nullifier::{Nullifier, NullifierKeyContainer},
     shielded_ptx::ShieldedPartialTransaction,
     transaction::{ShieldedPartialTxBundle, Transaction, TransparentPartialTxBundle},
@@ -74,24 +74,20 @@ pub fn create_transaction<R: RngCore + CryptoRng>(mut rng: R) -> Transaction {
     let ptx_1 = {
         // Create action pairs
         let actions = {
-            let rseed_1 = RandomSeed::random(&mut rng);
-            let anchor_1 = input_note_1.calculate_root(&merkle_path);
             let action_1 = ActionInfo::new(
                 *input_note_1.note(),
                 merkle_path.clone(),
-                anchor_1,
+                None,
                 *output_note_1.note(),
-                rseed_1,
+                &mut rng,
             );
 
-            let rseed_2 = RandomSeed::random(&mut rng);
-            let anchor_2 = input_note_2.calculate_root(&merkle_path);
             let action_2 = ActionInfo::new(
                 *input_note_2.note(),
                 merkle_path.clone(),
-                anchor_2,
+                None,
                 cascade_intent_note,
-                rseed_2,
+                &mut rng,
             );
             vec![action_1, action_2]
         };
@@ -155,23 +151,20 @@ pub fn create_transaction<R: RngCore + CryptoRng>(mut rng: R) -> Transaction {
     let ptx_2 = {
         // Create action pairs
         let actions = {
-            let rseed_1 = RandomSeed::random(&mut rng);
             let action_1 = ActionInfo::new(
                 cascade_intent_note,
                 merkle_path.clone(),
-                anchor,
+                Some(anchor),
                 *output_note_2.note(),
-                rseed_1,
+                &mut rng,
             );
 
-            let rseed_2 = RandomSeed::random(&mut rng);
-            let anchor_2 = input_note_3.calculate_root(&merkle_path);
             let action_2 = ActionInfo::new(
                 *input_note_3.note(),
                 merkle_path,
-                anchor_2,
+                None,
                 *output_note_3.note(),
-                rseed_2,
+                &mut rng,
             );
             vec![action_1, action_2]
         };

--- a/taiga_halo2/examples/tx_examples/partial_fulfillment_token_swap.rs
+++ b/taiga_halo2/examples/tx_examples/partial_fulfillment_token_swap.rs
@@ -17,7 +17,7 @@ use taiga_halo2::{
     },
     constant::TAIGA_COMMITMENT_TREE_DEPTH,
     merkle_tree::{Anchor, MerklePath},
-    note::{Note, NoteValidityPredicates, RandomSeed},
+    note::{Note, NoteValidityPredicates},
     nullifier::NullifierKeyContainer,
     shielded_ptx::ShieldedPartialTransaction,
     transaction::{ShieldedPartialTxBundle, Transaction, TransparentPartialTxBundle},
@@ -45,25 +45,22 @@ pub fn create_token_intent_ptx<R: RngCore>(
 
     // Create action pairs
     let actions = {
-        let rseed_1 = RandomSeed::random(&mut rng);
-        let anchor_1 = swap.sell.calculate_root(&merkle_path);
         let action_1 = ActionInfo::new(
             *swap.sell.note(),
             merkle_path.clone(),
-            anchor_1,
+            None,
             intent_note,
-            rseed_1,
+            &mut rng,
         );
 
         // Fetch a valid anchor for dummy notes
-        let anchor_2 = Anchor::from(pallas::Base::random(&mut rng));
-        let rseed_2 = RandomSeed::random(&mut rng);
+        let anchor = Anchor::from(pallas::Base::random(&mut rng));
         let action_2 = ActionInfo::new(
             padding_input_note,
             merkle_path,
-            anchor_2,
+            Some(anchor),
             padding_output_note,
-            rseed_2,
+            &mut rng,
         );
         vec![action_1, action_2]
     };
@@ -139,22 +136,20 @@ pub fn consume_token_intent_ptx<R: RngCore>(
 
     // Create action pairs
     let actions = {
-        let rseed_1 = RandomSeed::random(&mut rng);
         let action_1 = ActionInfo::new(
             intent_note,
             merkle_path.clone(),
-            anchor,
+            Some(anchor),
             bought_note,
-            rseed_1,
+            &mut rng,
         );
 
-        let rseed_2 = RandomSeed::random(&mut rng);
         let action_2 = ActionInfo::new(
             padding_input_note,
             merkle_path,
-            anchor,
+            Some(anchor),
             returned_note,
-            rseed_2,
+            &mut rng,
         );
         vec![action_1, action_2]
     };

--- a/taiga_halo2/examples/tx_examples/partial_fulfillment_token_swap.rs
+++ b/taiga_halo2/examples/tx_examples/partial_fulfillment_token_swap.rs
@@ -34,9 +34,8 @@ pub fn create_token_intent_ptx<R: RngCore>(
     let mut intent_note = swap.create_intent_note(&mut rng);
 
     // padding the zero notes
-    let padding_input_note = Note::random_padding_input_note(&mut rng);
-    let padding_input_note_nf = padding_input_note.get_nf().unwrap();
-    let mut padding_output_note = Note::random_padding_output_note(&mut rng, padding_input_note_nf);
+    let padding_input_note = Note::random_padding_note(&mut rng);
+    let mut padding_output_note = Note::random_padding_note(&mut rng);
     let merkle_path = MerklePath::random(&mut rng, TAIGA_COMMITMENT_TREE_DEPTH);
 
     // Create action pairs

--- a/taiga_halo2/examples/tx_examples/token.rs
+++ b/taiga_halo2/examples/tx_examples/token.rs
@@ -11,7 +11,7 @@ use taiga_halo2::{
     },
     constant::TAIGA_COMMITMENT_TREE_DEPTH,
     merkle_tree::{Anchor, MerklePath},
-    note::{Note, NoteValidityPredicates, RandomSeed},
+    note::{Note, NoteValidityPredicates},
     nullifier::{Nullifier, NullifierKeyContainer},
     shielded_ptx::ShieldedPartialTransaction,
 };
@@ -51,25 +51,22 @@ pub fn create_token_swap_ptx<R: RngCore>(
 
     // Create action pairs
     let actions = {
-        let rseed_1 = RandomSeed::random(&mut rng);
-        let anchor_1 = input_note.calculate_root(&merkle_path);
         let action_1 = ActionInfo::new(
             *input_note.note(),
             merkle_path.clone(),
-            anchor_1,
+            None,
             *output_note.note(),
-            rseed_1,
+            &mut rng,
         );
 
         // Fetch a valid anchor for padding input notes
-        let anchor_2 = Anchor::from(pallas::Base::random(&mut rng));
-        let rseed_2 = RandomSeed::random(&mut rng);
+        let anchor = Anchor::from(pallas::Base::random(&mut rng));
         let action_2 = ActionInfo::new(
             padding_input_note,
             merkle_path,
-            anchor_2,
+            Some(anchor),
             padding_output_note,
-            rseed_2,
+            &mut rng,
         );
         vec![action_1, action_2]
     };

--- a/taiga_halo2/examples/tx_examples/token.rs
+++ b/taiga_halo2/examples/tx_examples/token.rs
@@ -35,9 +35,8 @@ pub fn create_token_swap_ptx<R: RngCore>(
     let mut output_note = output_token.create_random_output_token_note(output_nk_com, &output_auth);
 
     // padding the zero notes
-    let padding_input_note = Note::random_padding_input_note(&mut rng);
-    let padding_input_note_nf = padding_input_note.get_nf().unwrap();
-    let mut padding_output_note = Note::random_padding_output_note(&mut rng, padding_input_note_nf);
+    let padding_input_note = Note::random_padding_note(&mut rng);
+    let mut padding_output_note = Note::random_padding_note(&mut rng);
 
     // Generate proving info
     let merkle_path = MerklePath::random(&mut rng, TAIGA_COMMITMENT_TREE_DEPTH);

--- a/taiga_halo2/examples/tx_examples/token_swap_with_intent.rs
+++ b/taiga_halo2/examples/tx_examples/token_swap_with_intent.rs
@@ -53,9 +53,8 @@ pub fn create_token_intent_ptx<R: RngCore>(
     );
 
     // padding the zero notes
-    let padding_input_note = Note::random_padding_input_note(&mut rng);
-    let padding_input_note_nf = padding_input_note.get_nf().unwrap();
-    let mut padding_output_note = Note::random_padding_output_note(&mut rng, padding_input_note_nf);
+    let padding_input_note = Note::random_padding_note(&mut rng);
+    let mut padding_output_note = Note::random_padding_note(&mut rng);
 
     let merkle_path = MerklePath::random(&mut rng, TAIGA_COMMITMENT_TREE_DEPTH);
 
@@ -169,9 +168,8 @@ pub fn consume_token_intent_ptx<R: RngCore>(
     let mut output_note = output_token.create_random_output_token_note(output_nk_com, &output_auth);
 
     // padding the zero notes
-    let padding_input_note = Note::random_padding_input_note(&mut rng);
-    let padding_input_note_nf = padding_input_note.get_nf().unwrap();
-    let mut padding_output_note = Note::random_padding_output_note(&mut rng, padding_input_note_nf);
+    let padding_input_note = Note::random_padding_note(&mut rng);
+    let mut padding_output_note = Note::random_padding_note(&mut rng);
 
     let merkle_path = MerklePath::random(&mut rng, TAIGA_COMMITMENT_TREE_DEPTH);
 

--- a/taiga_halo2/examples/tx_examples/token_swap_with_intent.rs
+++ b/taiga_halo2/examples/tx_examples/token_swap_with_intent.rs
@@ -17,7 +17,7 @@ use taiga_halo2::{
     },
     constant::TAIGA_COMMITMENT_TREE_DEPTH,
     merkle_tree::{Anchor, MerklePath},
-    note::{Note, NoteValidityPredicates, RandomSeed},
+    note::{Note, NoteValidityPredicates},
     nullifier::{Nullifier, NullifierKeyContainer},
     shielded_ptx::ShieldedPartialTransaction,
     transaction::{ShieldedPartialTxBundle, Transaction, TransparentPartialTxBundle},
@@ -68,25 +68,22 @@ pub fn create_token_intent_ptx<R: RngCore>(
 
     // Create action pairs
     let actions = {
-        let rseed_1 = RandomSeed::random(&mut rng);
-        let anchor_1 = input_note.calculate_root(&merkle_path);
         let action_1 = ActionInfo::new(
             *input_note.note(),
             merkle_path.clone(),
-            anchor_1,
+            None,
             intent_note,
-            rseed_1,
+            &mut rng,
         );
 
         // Fetch a valid anchor for padding input notes
-        let anchor_2 = Anchor::from(pallas::Base::random(&mut rng));
-        let rseed_2 = RandomSeed::random(&mut rng);
+        let anchor = Anchor::from(pallas::Base::random(&mut rng));
         let action_2 = ActionInfo::new(
             padding_input_note,
             merkle_path,
-            anchor_2,
+            Some(anchor),
             padding_output_note,
-            rseed_2,
+            &mut rng,
         );
         vec![action_1, action_2]
     };
@@ -198,22 +195,20 @@ pub fn consume_token_intent_ptx<R: RngCore>(
 
     // Create action pairs
     let actions = {
-        let rseed_1 = RandomSeed::random(&mut rng);
         let action_1 = ActionInfo::new(
             intent_note,
             merkle_path.clone(),
-            anchor,
+            Some(anchor),
             *output_note.note(),
-            rseed_1,
+            &mut rng,
         );
 
-        let rseed_2 = RandomSeed::random(&mut rng);
         let action_2 = ActionInfo::new(
             padding_input_note,
             merkle_path,
-            anchor,
+            Some(anchor),
             padding_output_note,
-            rseed_2,
+            &mut rng,
         );
         vec![action_1, action_2]
     };

--- a/taiga_halo2/examples/tx_examples/token_swap_with_intent.rs
+++ b/taiga_halo2/examples/tx_examples/token_swap_with_intent.rs
@@ -9,6 +9,7 @@ use halo2_proofs::arithmetic::Field;
 use pasta_curves::{group::Curve, pallas};
 use rand::{CryptoRng, RngCore};
 use taiga_halo2::{
+    action::ActionInfo,
     circuit::vp_examples::{
         or_relation_intent::{create_intent_note, OrRelationIntentValidityPredicateCircuit},
         signature_verification::COMPRESSED_TOKEN_AUTH_VK,
@@ -16,7 +17,7 @@ use taiga_halo2::{
     },
     constant::TAIGA_COMMITMENT_TREE_DEPTH,
     merkle_tree::{Anchor, MerklePath},
-    note::{InputNoteProvingInfo, Note, OutputNoteProvingInfo},
+    note::{Note, NoteValidityPredicates, RandomSeed},
     nullifier::{Nullifier, NullifierKeyContainer},
     shielded_ptx::ShieldedPartialTransaction,
     transaction::{ShieldedPartialTxBundle, Transaction, TransparentPartialTxBundle},
@@ -59,62 +60,86 @@ pub fn create_token_intent_ptx<R: RngCore>(
     let padding_input_note = Note::random_padding_input_note(&mut rng);
     let padding_input_note_nf = padding_input_note.get_nf().unwrap();
     let padding_output_note = Note::random_padding_output_note(&mut rng, padding_input_note_nf);
-    // Fetch a valid anchor for padding input notes
-    let anchor = Anchor::from(pallas::Base::random(&mut rng));
 
     let input_notes = [*input_note.note(), padding_input_note];
     let output_notes = [intent_note, padding_output_note];
 
     let merkle_path = MerklePath::random(&mut rng, TAIGA_COMMITMENT_TREE_DEPTH);
 
-    // Create the input note proving info
-    let input_note_proving_info = input_note.generate_input_token_note_proving_info(
-        &mut rng,
-        input_auth,
-        input_auth_sk,
-        merkle_path.clone(),
-        input_notes,
-        output_notes,
-    );
+    // Create action pairs
+    let actions = {
+        let rseed_1 = RandomSeed::random(&mut rng);
+        let anchor_1 = input_note.calculate_root(&merkle_path);
+        let action_1 = ActionInfo::new(
+            *input_note.note(),
+            merkle_path.clone(),
+            anchor_1,
+            intent_note,
+            rseed_1,
+        );
 
-    // Create the intent note proving info
-    let intent_note_proving_info = {
-        let intent_vp = OrRelationIntentValidityPredicateCircuit {
-            owned_note_pub_id: intent_note.commitment().inner(),
-            input_notes,
-            output_notes,
-            token_1,
-            token_2,
-            receiver_nk_com: input_note_nk_com,
-            receiver_app_data_dynamic: input_note.app_data_dynamic,
-        };
-
-        OutputNoteProvingInfo::new(intent_note, Box::new(intent_vp), vec![])
+        // Fetch a valid anchor for padding input notes
+        let anchor_2 = Anchor::from(pallas::Base::random(&mut rng));
+        let rseed_2 = RandomSeed::random(&mut rng);
+        let action_2 = ActionInfo::new(
+            padding_input_note,
+            merkle_path,
+            anchor_2,
+            padding_output_note,
+            rseed_2,
+        );
+        vec![action_1, action_2]
     };
 
-    // Create the padding input note proving info
-    let padding_input_note_proving_info = InputNoteProvingInfo::create_padding_note_proving_info(
-        padding_input_note,
-        merkle_path,
-        anchor,
-        input_notes,
-        output_notes,
-    );
+    // Create VPs
+    let (input_vps, output_vps) = {
+        // Create the input note vps
+        let input_note_vps = input_note.generate_input_token_vps(
+            &mut rng,
+            input_auth,
+            input_auth_sk,
+            input_notes,
+            output_notes,
+        );
 
-    // Create the padding output note proving info
-    let padding_output_note_proving_info = OutputNoteProvingInfo::create_padding_note_proving_info(
-        padding_output_note,
-        input_notes,
-        output_notes,
-    );
+        // Create the intent note proving info
+        let intent_note_vps = {
+            let intent_vp = OrRelationIntentValidityPredicateCircuit {
+                owned_note_pub_id: intent_note.commitment().inner(),
+                input_notes,
+                output_notes,
+                token_1,
+                token_2,
+                receiver_nk_com: input_note_nk_com,
+                receiver_app_data_dynamic: input_note.app_data_dynamic,
+            };
+
+            NoteValidityPredicates::new(Box::new(intent_vp), vec![])
+        };
+
+        // Create the padding input vps
+        let padding_input_vps = NoteValidityPredicates::create_input_padding_note_vps(
+            &padding_input_note,
+            input_notes,
+            output_notes,
+        );
+
+        // Create the padding output vps
+        let padding_output_vps = NoteValidityPredicates::create_output_padding_note_vps(
+            &padding_output_note,
+            input_notes,
+            output_notes,
+        );
+
+        (
+            vec![input_note_vps, padding_input_vps],
+            vec![intent_note_vps, padding_output_vps],
+        )
+    };
 
     // Create shielded partial tx
-    let ptx = ShieldedPartialTransaction::build(
-        [input_note_proving_info, padding_input_note_proving_info],
-        [intent_note_proving_info, padding_output_note_proving_info],
-        vec![],
-        &mut rng,
-    );
+    let ptx = ShieldedPartialTransaction::build(actions, input_vps, output_vps, vec![], &mut rng)
+        .unwrap();
 
     (
         ptx,
@@ -171,58 +196,71 @@ pub fn consume_token_intent_ptx<R: RngCore>(
     // Fetch a valid anchor for dummy notes
     let anchor = Anchor::from(pallas::Base::random(&mut rng));
 
-    // Create the intent note proving info
-    let intent_note_proving_info = {
-        let intent_vp = OrRelationIntentValidityPredicateCircuit {
-            owned_note_pub_id: input_note_nf.inner(),
-            input_notes,
-            output_notes,
-            token_1,
-            token_2,
-            receiver_nk_com,
-            receiver_app_data_dynamic,
-        };
-
-        InputNoteProvingInfo::new(
+    // Create action pairs
+    let actions = {
+        let rseed_1 = RandomSeed::random(&mut rng);
+        let action_1 = ActionInfo::new(
             intent_note,
             merkle_path.clone(),
-            Some(anchor),
-            Box::new(intent_vp),
-            vec![],
+            anchor,
+            *output_note.note(),
+            rseed_1,
+        );
+
+        let rseed_2 = RandomSeed::random(&mut rng);
+        let action_2 = ActionInfo::new(
+            padding_input_note,
+            merkle_path,
+            anchor,
+            padding_output_note,
+            rseed_2,
+        );
+        vec![action_1, action_2]
+    };
+
+    // Create VPs
+    let (input_vps, output_vps) = {
+        // Create intent vps
+        let intent_vps = {
+            let intent_vp = OrRelationIntentValidityPredicateCircuit {
+                owned_note_pub_id: input_note_nf.inner(),
+                input_notes,
+                output_notes,
+                token_1,
+                token_2,
+                receiver_nk_com,
+                receiver_app_data_dynamic,
+            };
+
+            NoteValidityPredicates::new(Box::new(intent_vp), vec![])
+        };
+
+        // Create the output token vps
+        let output_token_vps =
+            output_note.generate_output_token_vps(&mut rng, output_auth, input_notes, output_notes);
+
+        // Create the padding input vps
+        let padding_input_vps = NoteValidityPredicates::create_input_padding_note_vps(
+            &padding_input_note,
+            input_notes,
+            output_notes,
+        );
+
+        // Create the padding output vps
+        let padding_output_vps = NoteValidityPredicates::create_output_padding_note_vps(
+            &padding_output_note,
+            input_notes,
+            output_notes,
+        );
+
+        (
+            vec![intent_vps, padding_input_vps],
+            vec![output_token_vps, padding_output_vps],
         )
     };
 
-    // Create the output note proving info
-    let output_note_proving_info = output_note.generate_output_token_note_proving_info(
-        &mut rng,
-        output_auth,
-        input_notes,
-        output_notes,
-    );
-
-    // Create the padding input note proving info
-    let padding_input_note_proving_info = InputNoteProvingInfo::create_padding_note_proving_info(
-        padding_input_note,
-        merkle_path,
-        anchor,
-        input_notes,
-        output_notes,
-    );
-
-    // Create the padding output note proving info
-    let padding_output_note_proving_info = OutputNoteProvingInfo::create_padding_note_proving_info(
-        padding_output_note,
-        input_notes,
-        output_notes,
-    );
-
     // Create shielded partial tx
-    ShieldedPartialTransaction::build(
-        [intent_note_proving_info, padding_input_note_proving_info],
-        [output_note_proving_info, padding_output_note_proving_info],
-        vec![],
-        &mut rng,
-    )
+    ShieldedPartialTransaction::build(actions, input_vps, output_vps, vec![], &mut rng).unwrap()
 }
 
 pub fn create_token_swap_intent_transaction<R: RngCore + CryptoRng>(mut rng: R) -> Transaction {

--- a/taiga_halo2/examples/tx_examples/token_swap_without_intent.rs
+++ b/taiga_halo2/examples/tx_examples/token_swap_without_intent.rs
@@ -30,10 +30,10 @@ pub fn create_token_swap_transaction<R: RngCore + CryptoRng>(mut rng: R) -> Tran
         &mut rng,
         btc_token.clone(),
         alice_auth_sk,
-        alice_nk,
+        alice_nk.get_nk().unwrap(),
         eth_token.clone(),
         alice_auth_pk,
-        alice_nk.to_commitment(),
+        alice_nk.get_commitment(),
     );
 
     // Bob creates the partial transaction
@@ -45,10 +45,10 @@ pub fn create_token_swap_transaction<R: RngCore + CryptoRng>(mut rng: R) -> Tran
         &mut rng,
         eth_token,
         bob_auth_sk,
-        bob_nk,
+        bob_nk.get_nk().unwrap(),
         xan_token.clone(),
         bob_auth_pk,
-        bob_nk.to_commitment(),
+        bob_nk.get_commitment(),
     );
 
     // Carol creates the partial transaction
@@ -60,10 +60,10 @@ pub fn create_token_swap_transaction<R: RngCore + CryptoRng>(mut rng: R) -> Tran
         &mut rng,
         xan_token,
         carol_auth_sk,
-        carol_nk,
+        carol_nk.get_nk().unwrap(),
         btc_token,
         carol_auth_pk,
-        carol_nk.to_commitment(),
+        carol_nk.get_commitment(),
     );
 
     // Solver creates the final transaction

--- a/taiga_halo2/src/action.rs
+++ b/taiga_halo2/src/action.rs
@@ -2,13 +2,12 @@ use crate::{
     circuit::action_circuit::ActionCircuit,
     constant::{PRF_EXPAND_INPUT_VP_CM_R, PRF_EXPAND_OUTPUT_VP_CM_R},
     merkle_tree::{Anchor, MerklePath},
-    note::{InputNoteProvingInfo, Note, NoteCommitment, OutputNoteProvingInfo, RandomSeed},
+    note::{Note, NoteCommitment, RandomSeed},
     nullifier::Nullifier,
     value_commitment::ValueCommitment,
     vp_commitment::ValidityPredicateCommitment,
 };
 use pasta_curves::pallas;
-use rand::RngCore;
 
 #[cfg(feature = "nif")]
 use rustler::NifStruct;
@@ -128,21 +127,6 @@ impl ActionInfo {
             input_merkle_path,
             input_anchor,
             output_note,
-            rseed,
-        }
-    }
-
-    pub fn from_proving_info<R: RngCore>(
-        input: InputNoteProvingInfo,
-        output: OutputNoteProvingInfo,
-        mut rng: R,
-    ) -> Self {
-        let rseed = RandomSeed::random(&mut rng);
-        Self {
-            input_note: input.note,
-            input_merkle_path: input.merkle_path,
-            input_anchor: input.anchor,
-            output_note: output.note,
             rseed,
         }
     }

--- a/taiga_halo2/src/action.rs
+++ b/taiga_halo2/src/action.rs
@@ -131,7 +131,7 @@ impl ActionInfo {
             None => input_note.calculate_root(&input_merkle_path),
         };
 
-        output_note.reset_rho(&input_note, &mut rng);
+        output_note.set_rho(&input_note, &mut rng);
 
         Self {
             input_note,

--- a/taiga_halo2/src/action.rs
+++ b/taiga_halo2/src/action.rs
@@ -118,11 +118,12 @@ impl BorshDeserialize for ActionPublicInputs {
 impl ActionInfo {
     // The dummy input note must provide a valid custom_anchor, but a random merkle path
     // The normal input note only needs to provide a valid merkle path. The anchor will be calculated from the note and path.
+    // The rho of output_note will be reset to the nullifier of input_note
     pub fn new<R: RngCore>(
         input_note: Note,
         input_merkle_path: MerklePath,
         custom_anchor: Option<Anchor>,
-        output_note: Note,
+        output_note: &mut Note,
         mut rng: R,
     ) -> Self {
         let input_anchor = match custom_anchor {
@@ -130,11 +131,13 @@ impl ActionInfo {
             None => input_note.calculate_root(&input_merkle_path),
         };
 
+        output_note.reset_rho(&input_note, &mut rng);
+
         Self {
             input_note,
             input_merkle_path,
             input_anchor,
-            output_note,
+            output_note: *output_note,
             rseed: RandomSeed::random(&mut rng),
         }
     }
@@ -206,8 +209,14 @@ pub mod tests {
 
     pub fn random_action_info<R: RngCore>(mut rng: R) -> ActionInfo {
         let input_note = random_input_note(&mut rng);
-        let output_note = random_output_note(&mut rng, input_note.get_nf().unwrap());
+        let mut output_note = random_output_note(&mut rng, input_note.get_nf().unwrap());
         let input_merkle_path = MerklePath::random(&mut rng, TAIGA_COMMITMENT_TREE_DEPTH);
-        ActionInfo::new(input_note, input_merkle_path, None, output_note, &mut rng)
+        ActionInfo::new(
+            input_note,
+            input_merkle_path,
+            None,
+            &mut output_note,
+            &mut rng,
+        )
     }
 }

--- a/taiga_halo2/src/action.rs
+++ b/taiga_halo2/src/action.rs
@@ -204,12 +204,12 @@ pub mod tests {
     use super::ActionInfo;
     use crate::constant::TAIGA_COMMITMENT_TREE_DEPTH;
     use crate::merkle_tree::MerklePath;
-    use crate::note::tests::{random_input_note, random_output_note};
+    use crate::note::tests::random_note;
     use rand::RngCore;
 
     pub fn random_action_info<R: RngCore>(mut rng: R) -> ActionInfo {
-        let input_note = random_input_note(&mut rng);
-        let mut output_note = random_output_note(&mut rng, input_note.get_nf().unwrap());
+        let input_note = random_note(&mut rng);
+        let mut output_note = random_note(&mut rng);
         let input_merkle_path = MerklePath::random(&mut rng, TAIGA_COMMITMENT_TREE_DEPTH);
         ActionInfo::new(
             input_note,

--- a/taiga_halo2/src/circuit/vp_examples.rs
+++ b/taiga_halo2/src/circuit/vp_examples.rs
@@ -240,25 +240,15 @@ impl ValidityPredicateVerifyingInfo for TrivialValidityPredicateCircuit {
 #[cfg(test)]
 pub mod tests {
     use super::TrivialValidityPredicateCircuit;
-    use crate::{
-        constant::NUM_NOTE,
-        note::tests::{random_input_note, random_output_note},
-    };
+    use crate::{constant::NUM_NOTE, note::tests::random_note};
     use ff::Field;
     use pasta_curves::pallas;
     use rand::RngCore;
     pub fn random_trivial_vp_circuit<R: RngCore>(mut rng: R) -> TrivialValidityPredicateCircuit {
         let owned_note_pub_id = pallas::Base::random(&mut rng);
-        let input_notes = [(); NUM_NOTE].map(|_| random_input_note(&mut rng));
-        let output_notes = input_notes
-            .iter()
-            .map(|input| random_output_note(&mut rng, input.get_nf().unwrap()))
-            .collect::<Vec<_>>();
-        TrivialValidityPredicateCircuit::new(
-            owned_note_pub_id,
-            input_notes,
-            output_notes.try_into().unwrap(),
-        )
+        let input_notes = [(); NUM_NOTE].map(|_| random_note(&mut rng));
+        let output_notes = [(); NUM_NOTE].map(|_| random_note(&mut rng));
+        TrivialValidityPredicateCircuit::new(owned_note_pub_id, input_notes, output_notes)
     }
 
     #[test]

--- a/taiga_halo2/src/circuit/vp_examples/cascade_intent.rs
+++ b/taiga_halo2/src/circuit/vp_examples/cascade_intent.rs
@@ -171,27 +171,24 @@ pub fn create_intent_note<R: RngCore>(
 #[test]
 fn test_halo2_cascade_intent_vp_circuit() {
     use crate::constant::VP_CIRCUIT_PARAMS_SIZE;
-    use crate::note::tests::{random_input_note, random_output_note};
+    use crate::note::tests::random_note;
     use halo2_proofs::arithmetic::Field;
     use halo2_proofs::dev::MockProver;
     use rand::rngs::OsRng;
 
     let mut rng = OsRng;
     let circuit = {
-        let cascade_input_note = random_input_note(&mut rng);
+        let cascade_input_note = random_note(&mut rng);
         let cascade_note_cm = cascade_input_note.commitment().inner();
         let nk = pallas::Base::random(&mut rng);
         let intent_note = create_intent_note(&mut rng, cascade_note_cm, nk);
         let input_notes = [intent_note, cascade_input_note];
-        let output_notes = input_notes
-            .iter()
-            .map(|input| random_output_note(&mut rng, input.get_nf().unwrap()))
-            .collect::<Vec<_>>();
+        let output_notes = [(); NUM_NOTE].map(|_| random_note(&mut rng));
 
         CascadeIntentValidityPredicateCircuit {
             owned_note_pub_id: input_notes[0].get_nf().unwrap().inner(),
             input_notes,
-            output_notes: output_notes.try_into().unwrap(),
+            output_notes,
             cascade_note_cm,
         }
     };

--- a/taiga_halo2/src/circuit/vp_examples/field_addition.rs
+++ b/taiga_halo2/src/circuit/vp_examples/field_addition.rs
@@ -110,25 +110,22 @@ vp_verifying_info_impl!(FieldAdditionValidityPredicateCircuit);
 #[test]
 fn test_halo2_addition_vp_circuit() {
     use crate::constant::VP_CIRCUIT_PARAMS_SIZE;
-    use crate::note::tests::{random_input_note, random_output_note};
+    use crate::note::tests::random_note;
     use halo2_proofs::arithmetic::Field;
     use halo2_proofs::dev::MockProver;
     use rand::rngs::OsRng;
 
     let mut rng = OsRng;
     let circuit = {
-        let input_notes = [(); NUM_NOTE].map(|_| random_input_note(&mut rng));
-        let output_notes = input_notes
-            .iter()
-            .map(|input| random_output_note(&mut rng, input.get_nf().unwrap()))
-            .collect::<Vec<_>>();
+        let input_notes = [(); NUM_NOTE].map(|_| random_note(&mut rng));
+        let output_notes = [(); NUM_NOTE].map(|_| random_note(&mut rng));
         let a = pallas::Base::random(&mut rng);
         let b = pallas::Base::random(&mut rng);
         let owned_note_pub_id = pallas::Base::random(&mut rng);
         FieldAdditionValidityPredicateCircuit {
             owned_note_pub_id,
             input_notes,
-            output_notes: output_notes.try_into().unwrap(),
+            output_notes,
             a,
             b,
         }

--- a/taiga_halo2/src/circuit/vp_examples/or_relation_intent.rs
+++ b/taiga_halo2/src/circuit/vp_examples/or_relation_intent.rs
@@ -305,20 +305,14 @@ pub fn create_intent_note<R: RngCore>(
 #[test]
 fn test_halo2_or_relation_intent_vp_circuit() {
     use crate::constant::VP_CIRCUIT_PARAMS_SIZE;
-    use crate::{
-        circuit::vp_examples::token::COMPRESSED_TOKEN_VK, note::tests::random_output_note,
-        nullifier::tests::random_nullifier,
-    };
+    use crate::{circuit::vp_examples::token::COMPRESSED_TOKEN_VK, note::tests::random_note};
     use halo2_proofs::arithmetic::Field;
     use halo2_proofs::dev::MockProver;
     use rand::rngs::OsRng;
 
     let mut rng = OsRng;
     let circuit = {
-        let mut output_notes = [(); NUM_NOTE].map(|_| {
-            let padding_rho = random_nullifier(&mut rng);
-            random_output_note(&mut rng, padding_rho)
-        });
+        let mut output_notes = [(); NUM_NOTE].map(|_| random_note(&mut rng));
         let token_1 = Token::new("token1".to_string(), 1u64);
         let token_2 = Token::new("token2".to_string(), 2u64);
         output_notes[0].note_type.app_vk = *COMPRESSED_TOKEN_VK;
@@ -335,7 +329,7 @@ fn test_halo2_or_relation_intent_vp_circuit() {
             output_notes[0].app_data_dynamic,
             nk,
         );
-        let padding_input_note = Note::random_padding_input_note(&mut rng);
+        let padding_input_note = Note::random_padding_note(&mut rng);
         let input_notes = [intent_note, padding_input_note];
         OrRelationIntentValidityPredicateCircuit {
             owned_note_pub_id: input_notes[0].get_nf().unwrap().inner(),

--- a/taiga_halo2/src/circuit/vp_examples/partial_fulfillment_intent.rs
+++ b/taiga_halo2/src/circuit/vp_examples/partial_fulfillment_intent.rs
@@ -206,8 +206,6 @@ mod tests {
 
     #[test]
     fn create_intent() {
-        use crate::nullifier::Nullifier;
-
         let mut rng = OsRng;
         let sell = Token::new("token1".to_string(), 2u64);
         let buy = Token::new("token2".to_string(), 4u64);
@@ -215,9 +213,8 @@ mod tests {
         let swap = swap(&mut rng, sell, buy);
         let intent_note = swap.create_intent_note(&mut rng);
 
-        let input_padding_note = Note::random_padding_input_note(&mut rng);
-        let nf = Nullifier::random(&mut rng);
-        let output_padding_note = Note::random_padding_output_note(&mut rng, nf);
+        let input_padding_note = Note::random_padding_note(&mut rng);
+        let output_padding_note = Note::random_padding_note(&mut rng);
 
         let input_notes = [*swap.sell.note(), input_padding_note];
         let output_notes = [intent_note, output_padding_note];

--- a/taiga_halo2/src/circuit/vp_examples/partial_fulfillment_intent/swap.rs
+++ b/taiga_halo2/src/circuit/vp_examples/partial_fulfillment_intent/swap.rs
@@ -60,7 +60,7 @@ impl Swap {
             &self.auth,
         );
 
-        let input_padding_note = Note::random_padding_input_note(&mut rng);
+        let input_padding_note = Note::random_padding_note(&mut rng);
 
         let returned_note = if offer.value() < self.buy.value() {
             let filled_value = offer.value() / ratio;
@@ -74,7 +74,7 @@ impl Swap {
                 )
                 .note()
         } else {
-            Note::random_padding_output_note(&mut rng, input_padding_note.get_nf().unwrap())
+            Note::random_padding_note(&mut rng)
         };
 
         let input_notes = [intent_note, input_padding_note];

--- a/taiga_halo2/src/circuit/vp_examples/receiver_vp.rs
+++ b/taiga_halo2/src/circuit/vp_examples/receiver_vp.rs
@@ -285,21 +285,15 @@ vp_verifying_info_impl!(ReceiverValidityPredicateCircuit);
 #[test]
 fn test_halo2_receiver_vp_circuit() {
     use crate::constant::VP_CIRCUIT_PARAMS_SIZE;
-    use crate::{
-        note::tests::{random_input_note, random_output_note},
-        utils::poseidon_hash_n,
-    };
+    use crate::{note::tests::random_note, utils::poseidon_hash_n};
     use ff::{Field, PrimeField};
     use halo2_proofs::dev::MockProver;
     use rand::rngs::OsRng;
 
     let mut rng = OsRng;
     let (circuit, rcv_sk) = {
-        let input_notes = [(); NUM_NOTE].map(|_| random_input_note(&mut rng));
-        let mut output_notes = input_notes
-            .iter()
-            .map(|input| random_output_note(&mut rng, input.get_nf().unwrap()))
-            .collect::<Vec<_>>();
+        let input_notes = [(); NUM_NOTE].map(|_| random_note(&mut rng));
+        let mut output_notes = [(); NUM_NOTE].map(|_| random_note(&mut rng));
         let nonce = pallas::Base::from_u128(23333u128);
         let sk = pallas::Base::random(&mut rng);
         let rcv_sk = pallas::Base::random(&mut rng);
@@ -317,7 +311,7 @@ fn test_halo2_receiver_vp_circuit() {
             ReceiverValidityPredicateCircuit {
                 owned_note_pub_id,
                 input_notes,
-                output_notes: output_notes.try_into().unwrap(),
+                output_notes,
                 vp_vk: *COMPRESSED_RECEIVER_VK,
                 nonce,
                 sk,

--- a/taiga_halo2/src/circuit/vp_examples/signature_verification.rs
+++ b/taiga_halo2/src/circuit/vp_examples/signature_verification.rs
@@ -295,17 +295,14 @@ fn test_halo2_sig_verification_vp_circuit() {
         receiver_vp::COMPRESSED_RECEIVER_VK, token::TokenAuthorization,
     };
     use crate::constant::VP_CIRCUIT_PARAMS_SIZE;
-    use crate::note::tests::{random_input_note, random_output_note};
+    use crate::note::tests::random_note;
     use halo2_proofs::dev::MockProver;
     use rand::rngs::OsRng;
 
     let mut rng = OsRng;
     let circuit = {
-        let mut input_notes = [(); NUM_NOTE].map(|_| random_input_note(&mut rng));
-        let output_notes = input_notes
-            .iter()
-            .map(|input| random_output_note(&mut rng, input.get_nf().unwrap()))
-            .collect::<Vec<_>>();
+        let mut input_notes = [(); NUM_NOTE].map(|_| random_note(&mut rng));
+        let output_notes = [(); NUM_NOTE].map(|_| random_note(&mut rng));
         let sk = pallas::Scalar::random(&mut rng);
         let auth_vk = pallas::Base::random(&mut rng);
         let auth = TokenAuthorization::from_sk_vk(&sk, &auth_vk);
@@ -315,7 +312,7 @@ fn test_halo2_sig_verification_vp_circuit() {
             &mut rng,
             owned_note_pub_id,
             input_notes,
-            output_notes.try_into().unwrap(),
+            output_notes,
             auth_vk,
             sk,
             *COMPRESSED_RECEIVER_VK,

--- a/taiga_halo2/src/circuit/vp_examples/token.rs
+++ b/taiga_halo2/src/circuit/vp_examples/token.rs
@@ -533,17 +533,14 @@ impl TokenAuthorization {
 #[test]
 fn test_halo2_token_vp_circuit() {
     use crate::constant::VP_CIRCUIT_PARAMS_SIZE;
-    use crate::note::tests::{random_input_note, random_output_note};
+    use crate::note::tests::random_note;
     use halo2_proofs::dev::MockProver;
     use rand::rngs::OsRng;
 
     let mut rng = OsRng;
     let circuit = {
-        let mut input_notes = [(); NUM_NOTE].map(|_| random_input_note(&mut rng));
-        let output_notes = input_notes
-            .iter()
-            .map(|input| random_output_note(&mut rng, input.get_nf().unwrap()))
-            .collect::<Vec<_>>();
+        let mut input_notes = [(); NUM_NOTE].map(|_| random_note(&mut rng));
+        let output_notes = [(); NUM_NOTE].map(|_| random_note(&mut rng));
         let token_name = TokenName("Token_name".to_string());
         let auth = TokenAuthorization::random(&mut rng);
         input_notes[0].note_type.app_data_static = token_name.encode();
@@ -551,7 +548,7 @@ fn test_halo2_token_vp_circuit() {
         TokenValidityPredicateCircuit {
             owned_note_pub_id: input_notes[0].get_nf().unwrap().inner(),
             input_notes,
-            output_notes: output_notes.try_into().unwrap(),
+            output_notes,
             token_name,
             auth,
             receiver_vp_vk: *COMPRESSED_RECEIVER_VK,

--- a/taiga_halo2/src/note.rs
+++ b/taiga_halo2/src/note.rs
@@ -522,13 +522,13 @@ impl NoteValidityPredicates {
     pub fn create_input_padding_note_vps(
         note: &Note,
         input_notes: [Note; NUM_NOTE],
-        outputs_notes: [Note; NUM_NOTE],
+        output_notes: [Note; NUM_NOTE],
     ) -> Self {
         let note_id = note.get_nf().unwrap().inner();
         let application_vp = Box::new(TrivialValidityPredicateCircuit::new(
             note_id,
             input_notes,
-            outputs_notes,
+            output_notes,
         ));
         Self {
             application_vp,
@@ -540,13 +540,13 @@ impl NoteValidityPredicates {
     pub fn create_output_padding_note_vps(
         note: &Note,
         input_notes: [Note; NUM_NOTE],
-        outputs_notes: [Note; NUM_NOTE],
+        output_notes: [Note; NUM_NOTE],
     ) -> Self {
         let note_id = note.commitment().inner();
         let application_vp = Box::new(TrivialValidityPredicateCircuit::new(
             note_id,
             input_notes,
-            outputs_notes,
+            output_notes,
         ));
         Self {
             application_vp,

--- a/taiga_halo2/src/note.rs
+++ b/taiga_halo2/src/note.rs
@@ -281,7 +281,7 @@ impl Note {
         path.root(cm_node)
     }
 
-    pub fn reset_rho<R: RngCore>(&mut self, input_note: &Note, mut rng: R) {
+    pub fn set_rho<R: RngCore>(&mut self, input_note: &Note, mut rng: R) {
         let rseed = RandomSeed::random(&mut rng);
 
         self.rho = input_note.get_nf().unwrap();

--- a/taiga_halo2/src/shielded_ptx.rs
+++ b/taiga_halo2/src/shielded_ptx.rs
@@ -535,15 +535,7 @@ pub mod testing {
 
         // Construct action pair
         let merkle_path_1 = MerklePath::random(&mut rng, TAIGA_COMMITMENT_TREE_DEPTH);
-        let anchor_1 = input_note_1.calculate_root(&merkle_path_1);
-        let rseed_1 = RandomSeed::random(&mut rng);
-        let action_1 = ActionInfo::new(
-            input_note_1,
-            merkle_path_1,
-            anchor_1,
-            output_note_1,
-            rseed_1,
-        );
+        let action_1 = ActionInfo::new(input_note_1, merkle_path_1, None, output_note_1, &mut rng);
 
         // Generate notes
         let input_note_2 = {
@@ -587,15 +579,7 @@ pub mod testing {
 
         // Construct action pair
         let merkle_path_2 = MerklePath::random(&mut rng, TAIGA_COMMITMENT_TREE_DEPTH);
-        let anchor_2 = input_note_2.calculate_root(&merkle_path_2);
-        let rseed_2 = RandomSeed::random(&mut rng);
-        let action_2 = ActionInfo::new(
-            input_note_2,
-            merkle_path_2,
-            anchor_2,
-            output_note_2,
-            rseed_2,
-        );
+        let action_2 = ActionInfo::new(input_note_2, merkle_path_2, None, output_note_2, &mut rng);
 
         // Create vp circuit and fill the note info
         let mut trivial_vp_circuit = TrivialValidityPredicateCircuit {

--- a/taiga_halo2/src/shielded_ptx.rs
+++ b/taiga_halo2/src/shielded_ptx.rs
@@ -470,7 +470,7 @@ pub mod testing {
         constant::TAIGA_COMMITMENT_TREE_DEPTH,
         merkle_tree::MerklePath,
         note::{Note, NoteValidityPredicates, RandomSeed},
-        nullifier::{Nullifier, NullifierKeyContainer},
+        nullifier::Nullifier,
         shielded_ptx::ShieldedPartialTransaction,
         utils::poseidon_hash,
     };
@@ -497,10 +497,10 @@ pub mod testing {
             let app_data_dynamic = poseidon_hash(app_dynamic_vp_vk[0], app_dynamic_vp_vk[1]);
             let rho = Nullifier::from(pallas::Base::random(&mut rng));
             let value = 5000u64;
-            let nk = NullifierKeyContainer::random_key(&mut rng);
+            let nk = pallas::Base::random(&mut rng);
             let rseed = RandomSeed::random(&mut rng);
             let is_merkle_checked = true;
-            Note::new(
+            Note::new_input_note(
                 compressed_trivial_vp_vk,
                 app_data_static,
                 app_data_dynamic,
@@ -511,31 +511,33 @@ pub mod testing {
                 rseed,
             )
         };
-        let output_note_1 = {
+        let mut output_note_1 = {
             let app_data_static = pallas::Base::zero();
             // TODO: add real application dynamic VPs and encode them to app_data_dynamic later.
             // If the dynamic VP is not used, set app_data_dynamic pallas::Base::zero() by default.
             let app_data_dynamic = pallas::Base::zero();
-            let rho = input_note_1.get_nf().unwrap();
             let value = 5000u64;
-            let nk_com = NullifierKeyContainer::random_commitment(&mut rng);
-            let rseed = RandomSeed::random(&mut rng);
+            let nk_com = pallas::Base::random(&mut rng);
             let is_merkle_checked = true;
-            Note::new(
+            Note::new_output_note(
                 compressed_trivial_vp_vk,
                 app_data_static,
                 app_data_dynamic,
                 value,
                 nk_com,
-                rho,
                 is_merkle_checked,
-                rseed,
             )
         };
 
         // Construct action pair
         let merkle_path_1 = MerklePath::random(&mut rng, TAIGA_COMMITMENT_TREE_DEPTH);
-        let action_1 = ActionInfo::new(input_note_1, merkle_path_1, None, output_note_1, &mut rng);
+        let action_1 = ActionInfo::new(
+            input_note_1,
+            merkle_path_1,
+            None,
+            &mut output_note_1,
+            &mut rng,
+        );
 
         // Generate notes
         let input_note_2 = {
@@ -543,10 +545,10 @@ pub mod testing {
             let app_data_dynamic = pallas::Base::zero();
             let rho = Nullifier::from(pallas::Base::random(&mut rng));
             let value = 10u64;
-            let nk = NullifierKeyContainer::random_key(&mut rng);
+            let nk = pallas::Base::random(&mut rng);
             let rseed = RandomSeed::random(&mut rng);
             let is_merkle_checked = true;
-            Note::new(
+            Note::new_input_note(
                 compressed_trivial_vp_vk,
                 app_data_static,
                 app_data_dynamic,
@@ -557,29 +559,31 @@ pub mod testing {
                 rseed,
             )
         };
-        let output_note_2 = {
+        let mut output_note_2 = {
             let app_data_static = pallas::Base::one();
             let app_data_dynamic = pallas::Base::zero();
-            let rho = input_note_2.get_nf().unwrap();
             let value = 10u64;
-            let nk_com = NullifierKeyContainer::random_commitment(&mut rng);
-            let rseed = RandomSeed::random(&mut rng);
+            let nk_com = pallas::Base::random(&mut rng);
             let is_merkle_checked = true;
-            Note::new(
+            Note::new_output_note(
                 compressed_trivial_vp_vk,
                 app_data_static,
                 app_data_dynamic,
                 value,
                 nk_com,
-                rho,
                 is_merkle_checked,
-                rseed,
             )
         };
 
         // Construct action pair
         let merkle_path_2 = MerklePath::random(&mut rng, TAIGA_COMMITMENT_TREE_DEPTH);
-        let action_2 = ActionInfo::new(input_note_2, merkle_path_2, None, output_note_2, &mut rng);
+        let action_2 = ActionInfo::new(
+            input_note_2,
+            merkle_path_2,
+            None,
+            &mut output_note_2,
+            &mut rng,
+        );
 
         // Create vp circuit and fill the note info
         let mut trivial_vp_circuit = TrivialValidityPredicateCircuit {

--- a/taiga_halo2/src/taiga_api.rs
+++ b/taiga_halo2/src/taiga_api.rs
@@ -227,15 +227,14 @@ pub fn verify_shielded_partial_transaction(ptx_bytes: Vec<u8>) -> Result<(), Tra
 #[cfg(feature = "borsh")]
 pub mod tests {
     use crate::{
-        note::tests::{random_input_note, random_output_note},
-        taiga_api::*,
+        note::tests::random_note, nullifier::tests::random_nullifier_key_commitment, taiga_api::*,
     };
     use rand::rngs::OsRng;
 
     #[test]
     fn note_borsh_serialization_api_test() {
         let mut rng = OsRng;
-        let input_note = random_input_note(&mut rng);
+        let input_note = random_note(&mut rng);
         {
             let bytes = note_serialize(&input_note).unwrap();
             let de_input_note = note_deserialize(bytes).unwrap();
@@ -243,28 +242,29 @@ pub mod tests {
         }
 
         {
-            let output_note = random_output_note(&mut rng, input_note.rho);
+            let mut output_note = input_note;
+            output_note.nk_container = random_nullifier_key_commitment(&mut rng);
             let bytes = note_serialize(&output_note).unwrap();
             let de_output_note = note_deserialize(bytes).unwrap();
             assert_eq!(output_note, de_output_note);
         }
     }
 
-    #[ignore]
+    // #[ignore]
     #[test]
     fn ptx_example_test() {
         use crate::action::ActionInfo;
         use crate::circuit::vp_examples::TrivialValidityPredicateCircuit;
         use crate::constant::TAIGA_COMMITMENT_TREE_DEPTH;
         use crate::merkle_tree::MerklePath;
-        use crate::note::tests::{random_input_note, random_output_note};
+        use crate::note::tests::random_note;
 
         let mut rng = OsRng;
 
         // construct notes
-        let input_note_1 = random_input_note(&mut rng);
+        let input_note_1 = random_note(&mut rng);
         let input_note_1_nf = input_note_1.get_nf().unwrap();
-        let mut output_note_1 = random_output_note(&mut rng, input_note_1_nf);
+        let mut output_note_1 = random_note(&mut rng);
         let merkle_path_1 = MerklePath::random(&mut rng, TAIGA_COMMITMENT_TREE_DEPTH);
         let action_1 = ActionInfo::new(
             input_note_1,
@@ -274,9 +274,9 @@ pub mod tests {
             &mut rng,
         );
 
-        let input_note_2 = random_input_note(&mut rng);
+        let input_note_2 = random_note(&mut rng);
         let input_note_2_nf = input_note_2.get_nf().unwrap();
-        let mut output_note_2 = random_output_note(&mut rng, input_note_2_nf);
+        let mut output_note_2 = random_note(&mut rng);
         let merkle_path_2 = MerklePath::random(&mut rng, TAIGA_COMMITMENT_TREE_DEPTH);
         let action_2 = ActionInfo::new(
             input_note_2,

--- a/taiga_halo2/src/taiga_api.rs
+++ b/taiga_halo2/src/taiga_api.rs
@@ -265,10 +265,7 @@ pub mod tests {
         use crate::circuit::vp_examples::TrivialValidityPredicateCircuit;
         use crate::constant::TAIGA_COMMITMENT_TREE_DEPTH;
         use crate::merkle_tree::MerklePath;
-        use crate::note::{
-            tests::{random_input_note, random_output_note},
-            RandomSeed,
-        };
+        use crate::note::tests::{random_input_note, random_output_note};
 
         let mut rng = OsRng;
 
@@ -277,29 +274,13 @@ pub mod tests {
         let input_note_1_nf = input_note_1.get_nf().unwrap();
         let output_note_1 = random_output_note(&mut rng, input_note_1_nf);
         let merkle_path_1 = MerklePath::random(&mut rng, TAIGA_COMMITMENT_TREE_DEPTH);
-        let anchor_1 = input_note_1.calculate_root(&merkle_path_1);
-        let rseed_1 = RandomSeed::random(&mut rng);
-        let action_1 = ActionInfo::new(
-            input_note_1,
-            merkle_path_1,
-            anchor_1,
-            output_note_1,
-            rseed_1,
-        );
+        let action_1 = ActionInfo::new(input_note_1, merkle_path_1, None, output_note_1, &mut rng);
 
         let input_note_2 = random_input_note(&mut rng);
         let input_note_2_nf = input_note_2.get_nf().unwrap();
         let output_note_2 = random_output_note(&mut rng, input_note_2_nf);
         let merkle_path_2 = MerklePath::random(&mut rng, TAIGA_COMMITMENT_TREE_DEPTH);
-        let anchor_2 = input_note_2.calculate_root(&merkle_path_2);
-        let rseed_2 = RandomSeed::random(&mut rng);
-        let action_2 = ActionInfo::new(
-            input_note_2,
-            merkle_path_2,
-            anchor_2,
-            output_note_2,
-            rseed_2,
-        );
+        let action_2 = ActionInfo::new(input_note_2, merkle_path_2, None, output_note_2, &mut rng);
 
         // construct applications
         let input_note_1_app = {

--- a/taiga_halo2/src/transparent_ptx.rs
+++ b/taiga_halo2/src/transparent_ptx.rs
@@ -12,14 +12,34 @@ use serde;
 
 #[cfg(feature = "borsh")]
 use borsh::{BorshDeserialize, BorshSerialize};
+use rand::RngCore;
 
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TransparentPartialTransaction {
-    pub inputs: Vec<InputResource>,
-    pub outputs: Vec<OutputResource>,
-    pub hints: Vec<u8>,
+    inputs: Vec<InputResource>,
+    outputs: Vec<OutputResource>,
+    hints: Vec<u8>,
+}
+
+impl TransparentPartialTransaction {
+    pub fn new<R: RngCore>(
+        inputs: Vec<InputResource>,
+        mut outputs: Vec<OutputResource>,
+        hints: Vec<u8>,
+        mut rng: R,
+    ) -> Self {
+        outputs
+            .iter_mut()
+            .zip(inputs.iter())
+            .for_each(|(output, input)| output.note.reset_rho(&input.note, &mut rng));
+        Self {
+            inputs,
+            outputs,
+            hints,
+        }
+    }
 }
 
 impl Executable for TransparentPartialTransaction {
@@ -102,9 +122,7 @@ pub struct OutputResource {
 #[cfg(test)]
 pub mod testing {
     use crate::{
-        constant::TAIGA_COMMITMENT_TREE_DEPTH,
-        merkle_tree::MerklePath,
-        note::tests::{random_input_note, random_output_note},
+        constant::TAIGA_COMMITMENT_TREE_DEPTH, merkle_tree::MerklePath, note::tests::random_note,
         transparent_ptx::*,
     };
     use rand::rngs::OsRng;
@@ -113,7 +131,7 @@ pub mod testing {
     pub fn create_transparent_ptx() -> TransparentPartialTransaction {
         let mut rng = OsRng;
         let input_resource_1 = {
-            let note = random_input_note(&mut rng);
+            let note = random_note(&mut rng);
             let merkle_path = MerklePath::random(&mut rng, TAIGA_COMMITMENT_TREE_DEPTH);
             InputResource {
                 note,
@@ -121,7 +139,7 @@ pub mod testing {
             }
         };
         let output_resource_1 = {
-            let mut note = random_output_note(&mut rng, input_resource_1.note.rho);
+            let mut note = random_note(&mut rng);
             // Adjust the random note to keep the balance
             note.note_type = input_resource_1.note.note_type;
             note.value = input_resource_1.note.value;
@@ -129,7 +147,7 @@ pub mod testing {
         };
 
         let input_resource_2 = {
-            let mut note = random_input_note(&mut rng);
+            let mut note = random_note(&mut rng);
             note.is_merkle_checked = false;
             InputResource {
                 note,
@@ -137,17 +155,18 @@ pub mod testing {
             }
         };
         let output_resource_2 = {
-            let mut note = random_output_note(&mut rng, input_resource_2.note.rho);
+            let mut note = random_note(&mut rng);
             // Adjust the random note to keep the balance
             note.note_type = input_resource_2.note.note_type;
             note.value = input_resource_2.note.value;
             OutputResource { note }
         };
 
-        TransparentPartialTransaction {
-            inputs: vec![input_resource_1, input_resource_2],
-            outputs: vec![output_resource_1, output_resource_2],
-            hints: vec![],
-        }
+        TransparentPartialTransaction::new(
+            vec![input_resource_1, input_resource_2],
+            vec![output_resource_1, output_resource_2],
+            vec![],
+            &mut rng,
+        )
     }
 }

--- a/taiga_halo2/src/transparent_ptx.rs
+++ b/taiga_halo2/src/transparent_ptx.rs
@@ -33,7 +33,7 @@ impl TransparentPartialTransaction {
         outputs
             .iter_mut()
             .zip(inputs.iter())
-            .for_each(|(output, input)| output.note.reset_rho(&input.note, &mut rng));
+            .for_each(|(output, input)| output.note.set_rho(&input.note, &mut rng));
         Self {
             inputs,
             outputs,


### PR DESCRIPTION
* Separate the action and VPs construction processes in the ptx building
* simplify action construction
* automatically reset the `rho` of output notes when constructing the Action. We won't need to explicitly set the output note `rho,` which comes from the `nullifier` of the input note.
* simplify the random and padding note creation
